### PR TITLE
fix: correct repo url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Add the following to your configuration...
 {
   "mcpServers": {
     "actualBudget": {
-      "command": "node",
+      "command": "npx",
       "args": ["-y", "actual-mcp", "--enable-write"],
       "env": {
         "ACTUAL_DATA_DIR": "path/to/your/data",


### PR DESCRIPTION
The repo url mentioned in the README instructions is not correct, I guess the username changed? This corrects it again :)
It also replaces `node` command in the npx example with calling `npx` instead, node will not work this way