### PR TITLE
feat: Add Streamable HTTP transport for Codex CLI compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,18 @@ Once connected, you can ask Claude questions like:
 - "What's my savings rate over the past 3 months?"
 - "Analyze my budget and suggest areas to improve"
 
+## Usage with Codex CLI
+
+Example Codex configuration:
+
+In `~/.codex/config.toml`:
+```toml
+[mcp_servers.actual-budget]
+url = "http://localhost:3000"
+```
+
+Point Codex at the same port you pass to `npm start -- --sse --port <PORT>`.
+
 ## Development
 
 For development with auto-rebuild:

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,16 +12,18 @@
  */
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import dotenv from 'dotenv';
 import express, { NextFunction, Request, Response } from 'express';
+import { randomUUID } from 'node:crypto';
 import { parseArgs } from 'node:util';
 import { initActualApi, shutdownActualApi } from './actual-api.js';
 import { fetchAllAccounts } from './core/data/fetch-accounts.js';
 import { setupPrompts } from './prompts.js';
 import { setupResources } from './resources.js';
 import { setupTools } from './tools/index.js';
-import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { SetLevelRequestSchema, isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 
 dotenv.config({ path: '.env' });
 
@@ -109,6 +111,20 @@ const bearerAuth = (req: Request, res: Response, next: NextFunction): void => {
   next();
 };
 
+/**
+ * Safely stringify values for logging without throwing on circular structures.
+ */
+const safeStringify = (value: unknown): string => {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '[unserializable]';
+  }
+};
+
+const toErrorMessage = (value: unknown): string =>
+  value instanceof Error ? `${value.name}: ${value.message}` : safeStringify(value);
+
 // ----------------------------
 // SERVER STARTUP
 // ----------------------------
@@ -171,12 +187,23 @@ async function main(): Promise<void> {
       console.error('Bearer authentication disabled - endpoints are public');
     }
 
-    // Placeholder for future HTTP transport (stateless)
-    app.post('/mcp', bearerAuth, async (req: Request, res: Response) => {
-      res.status(501).json({ error: 'HTTP transport not implemented yet' });
+    const streamableHttpTransports = new Map<string, StreamableHTTPServerTransport>();
+
+    const parseSessionHeader = (value: string | string[] | undefined): string | undefined => {
+      if (!value) {
+        return undefined;
+      }
+      return Array.isArray(value) ? value[0] : value;
+    };
+
+    app.get(['/.well-known/oauth-authorization-server', '/.well-known/oauth-authorization-server/sse'], (_req, res) => {
+      res.status(404).json({ error: 'OAuth metadata not configured for this server' });
+    });
+    app.get(['/sse/.well-known/oauth-authorization-server'], (_req, res) => {
+      res.status(404).json({ error: 'OAuth metadata not configured for this server' });
     });
 
-    app.get('/sse', bearerAuth, (req: Request, res: Response) => {
+    const handleLegacySse = (req: Request, res: Response): void => {
       transport = new SSEServerTransport('/messages', res);
       server.connect(transport).then(() => {
         console.log = (message: string) => server.sendLoggingMessage({ level: 'info', message });
@@ -185,7 +212,107 @@ async function main(): Promise<void> {
 
         console.error(`Actual Budget MCP Server (SSE) started on port ${resolvedPort}`);
       });
+    };
+
+    app.get('/sse', bearerAuth, handleLegacySse);
+
+    const streamablePaths = ['/', '/mcp'];
+
+    app.all(streamablePaths, bearerAuth, async (req: Request, res: Response) => {
+      const sessionHeader = parseSessionHeader(req.headers['mcp-session-id']);
+      if (req.method === 'GET' && !sessionHeader && req.headers.accept?.includes('text/event-stream')) {
+        handleLegacySse(req, res);
+        return;
+      }
+      const requestLabel = `${req.method} ${req.path}`;
+      try {
+        let streamableTransport = sessionHeader ? streamableHttpTransports.get(sessionHeader) : undefined;
+
+        if (!streamableTransport) {
+          if (req.method === 'POST' && isInitializeRequest(req.body)) {
+            const remoteAddress = req.ip ?? req.socket.remoteAddress ?? 'unknown';
+            streamableTransport = new StreamableHTTPServerTransport({
+              sessionIdGenerator: () => randomUUID(),
+              onsessioninitialized: (sessionId) => {
+                streamableHttpTransports.set(sessionId, streamableTransport!);
+                console.info(`Streamable HTTP session initialized (session ${sessionId}) from ${remoteAddress}`);
+              },
+              onsessionclosed: (sessionId) => {
+                streamableHttpTransports.delete(sessionId);
+                console.info(`Streamable HTTP session closed (session ${sessionId})`);
+              },
+            });
+
+            streamableTransport.onclose = () => {
+              const activeSessionId = streamableTransport?.sessionId;
+              if (activeSessionId) {
+                streamableHttpTransports.delete(activeSessionId);
+                console.info(`Streamable HTTP transport closed (session ${activeSessionId})`);
+              }
+            };
+
+            try {
+              await server.connect(streamableTransport);
+
+              console.log = (message: string) => server.sendLoggingMessage({ level: 'info', message });
+
+              console.error = (message: string) => server.sendLoggingMessage({ level: 'error', message });
+
+              console.error(`Actual Budget MCP Server (Streamable HTTP) started on port ${resolvedPort}`);
+            } catch (error) {
+              console.error(`Failed to connect streamable HTTP transport: ${toErrorMessage(error)}`);
+              res.status(500).json({
+                jsonrpc: '2.0',
+                error: {
+                  code: -32603,
+                  message: 'Internal server error',
+                },
+                id: null,
+              });
+              return;
+            }
+          } else {
+            res.status(400).json({
+              jsonrpc: '2.0',
+              error: {
+                code: -32000,
+                message: 'Bad Request: No valid session ID provided',
+              },
+              id: null,
+            });
+            return;
+          }
+        }
+
+        if (!streamableTransport) {
+          res.status(500).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: 'Internal server error',
+            },
+            id: null,
+          });
+          return;
+        }
+
+        await streamableTransport.handleRequest(req, res, req.body);
+      } catch (error) {
+        console.error(`Streamable HTTP handler error for ${requestLabel}: ${toErrorMessage(error)}`);
+
+        if (!res.headersSent) {
+          res.status(500).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: 'Internal server error',
+            },
+            id: null,
+          });
+        }
+      }
     });
+
     app.post('/messages', bearerAuth, async (req: Request, res: Response) => {
       if (transport) {
         await transport.handlePostMessage(req, res, req.body);
@@ -240,6 +367,6 @@ main()
     }
   })
   .catch((error: unknown) => {
-    console.error('Server error:', error);
+    console.error(`Server error: ${toErrorMessage(error)}`);
     process.exit(1);
   });


### PR DESCRIPTION
**Summary** 

This PR provides support for use with [Codex CLI](https://github.com/openai/codex).

-   add a Streamable HTTP handler on / and /mcp so Codex can POST the MCP initialize request without 404s
-   retain the existing /sse endpoint and fall back to it when legacy clients GET with Accept: text/event-stream and no session
-   document the new Codex usage in the README

 Note in “Testing” that Streamable HTTP handshake is verified manually with Codex and legacy SSE clients still connect.