### PR TITLE
feat: add run-bank-sync tool

### DIFF
--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -256,3 +256,17 @@ export async function deleteTransaction(id: string): Promise<unknown> {
   await initActualApi();
   return api.deleteTransaction(id);
 }
+
+/**
+ * Run bank sync for accounts (ensures API is initialized)
+ *
+ * @param accountId - Optional. Specific account ID, or special value:
+ *   - "onbudget": sync all on-budget linked accounts
+ *   - "offbudget": sync all off-budget linked accounts
+ *   - undefined: sync ALL linked accounts
+ */
+export async function runBankSync(accountId?: string): Promise<void> {
+  await initActualApi();
+  // API expects { accountId } object or undefined for all accounts
+  return api.runBankSync(accountId ? { accountId } : undefined);
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -30,6 +30,7 @@ import * as spendingByCategory from './spending-by-category/index.js';
 import * as deleteTransaction from './delete-transaction/index.js';
 import * as updateTransaction from './update-transaction/index.js';
 import * as createTransaction from './create-transaction/index.js';
+import * as runBankSync from './run-bank-sync/index.js';
 
 const readTools = [
   getTransactions,
@@ -58,6 +59,7 @@ const writeTools = [
   updateTransaction,
   deleteTransaction,
   createTransaction,
+  runBankSync,
 ];
 
 export const setupTools = (server: Server, enableWrite: boolean): void => {

--- a/src/tools/run-bank-sync/index.test.ts
+++ b/src/tools/run-bank-sync/index.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../actual-api.js', () => ({
+  runBankSync: vi.fn(),
+}));
+
+import { runBankSync } from '../../actual-api.js';
+
+describe('run-bank-sync tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('run-bank-sync');
+      expect(schema.description).toContain('bank synchronization');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should sync specific account when accountId provided', async () => {
+      vi.mocked(runBankSync).mockResolvedValue(undefined);
+
+      const result = await handler({ accountId: 'acc-123' });
+
+      expect(runBankSync).toHaveBeenCalledWith('acc-123');
+      expect(result.content[0]).toHaveProperty('text');
+      expect((result.content[0] as { text: string }).text).toContain('acc-123');
+    });
+
+    it('should sync all accounts when no accountId provided', async () => {
+      vi.mocked(runBankSync).mockResolvedValue(undefined);
+
+      const result = await handler({});
+
+      expect(runBankSync).toHaveBeenCalledWith(undefined);
+      expect(result.content[0]).toHaveProperty('text');
+      expect((result.content[0] as { text: string }).text).toContain('all linked accounts');
+    });
+
+    it('should sync onbudget accounts with special value', async () => {
+      vi.mocked(runBankSync).mockResolvedValue(undefined);
+
+      const result = await handler({ accountId: 'onbudget' });
+
+      expect(runBankSync).toHaveBeenCalledWith('onbudget');
+      expect((result.content[0] as { text: string }).text).toContain('on-budget');
+    });
+
+    it('should sync offbudget accounts with special value', async () => {
+      vi.mocked(runBankSync).mockResolvedValue(undefined);
+
+      const result = await handler({ accountId: 'offbudget' });
+
+      expect(runBankSync).toHaveBeenCalledWith('offbudget');
+      expect((result.content[0] as { text: string }).text).toContain('off-budget');
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should return error when accountId is not a string', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await handler({ accountId: 123 } as any);
+
+      expect(result.isError).toBe(true);
+      expect(runBankSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle sync errors', async () => {
+      vi.mocked(runBankSync).mockRejectedValue(new Error('Bank sync failed'));
+
+      const result = await handler({ accountId: 'acc-123' });
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('Bank sync failed');
+    });
+
+    it('should handle network errors', async () => {
+      vi.mocked(runBankSync).mockRejectedValue(new Error('Network error'));
+
+      const result = await handler({});
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('Network error');
+    });
+  });
+});

--- a/src/tools/run-bank-sync/index.ts
+++ b/src/tools/run-bank-sync/index.ts
@@ -1,0 +1,61 @@
+// ----------------------------
+// RUN BANK SYNC TOOL
+// ----------------------------
+
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { success, errorFromCatch } from '../../utils/response.js';
+import { runBankSync } from '../../actual-api.js';
+import type { ToolInput } from '../../types.js';
+
+const RunBankSyncArgsSchema = z.object({
+  accountId: z
+    .string()
+    .optional()
+    .describe(
+      'Account ID to sync, or special value: "onbudget" (all on-budget), ' +
+        '"offbudget" (all off-budget). If omitted, syncs ALL linked accounts.'
+    ),
+});
+
+type RunBankSyncArgs = z.infer<typeof RunBankSyncArgsSchema>;
+
+export const schema = {
+  name: 'run-bank-sync',
+  description:
+    'Run bank synchronization (GoCardless/SimpleFIN) to download latest transactions. ' +
+    'Provide accountId for a specific account, use "onbudget"/"offbudget" for groups, ' +
+    'or omit to sync all linked accounts.',
+  inputSchema: zodToJsonSchema(RunBankSyncArgsSchema) as ToolInput,
+};
+
+export async function handler(args: RunBankSyncArgs): Promise<CallToolResult> {
+  try {
+    const validatedArgs = RunBankSyncArgsSchema.parse(args);
+    const { accountId } = validatedArgs;
+
+    // API handles all sync logic natively:
+    // - specific ID → sync that account
+    // - "onbudget" → sync on-budget accounts
+    // - "offbudget" → sync off-budget accounts
+    // - undefined → sync ALL linked accounts
+    await runBankSync(accountId);
+
+    // Build user-friendly response
+    let message: string;
+    if (!accountId) {
+      message = 'Bank sync completed for all linked accounts.';
+    } else if (accountId === 'onbudget') {
+      message = 'Bank sync completed for all on-budget linked accounts.';
+    } else if (accountId === 'offbudget') {
+      message = 'Bank sync completed for all off-budget linked accounts.';
+    } else {
+      message = `Bank sync completed for account: ${accountId}`;
+    }
+
+    return success(message);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}


### PR DESCRIPTION
Add MCP tool to trigger bank synchronization (GoCardless/SimpleFIN) for downloading latest transactions via LLM.

Supports:
- Specific account sync by ID
- All on-budget accounts ("onbudget")
- All off-budget accounts ("offbudget")
- All linked accounts (no accountId)

cc: closes #23 