### PR TITLE
chore: add .gitattributes for line ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Auto detect text files and normalize line endings
+* text=auto
+
+# Source files - force LF
+*.ts text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Reduce diff noise for lock files
+package-lock.json -diff


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` to ensure consistent line endings across platforms
- Marks `package-lock.json` as `-diff` to reduce PR noise

## Why
- Prevents CRLF/LF issues when contributors work on different operating systems
- Makes PRs with dependency updates easier to review by hiding lock file diffs