### PR TITLE
fix(deps): update @actual-app/api to 26.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/api": "25.11.0",
+        "@actual-app/api": "26.1.0",
         "@modelcontextprotocol/sdk": "1.17.4",
         "dotenv": "17.2.3",
         "express": "5.2.1",
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "25.11.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-25.11.0.tgz",
-      "integrity": "sha512-ER4QvoS8l2Q+BBeiJHY6/wqmNbu3VPdUHVvVGwl104jKo9c0AwvNe7u1v0ckvy56hkqc8Z3zop8RXn0EBZuxDw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.1.0.tgz",
+      "integrity": "sha512-AXAQ93++XeCZdVU/wkxellxeehNfL0Zx7kSEDsW84nSVInuqmo+mlk5oi+fRpuXAcITLpkk9YcznYhKI7HfExg==",
       "license": "MIT",
       "dependencies": {
         "@actual-app/crdt": "^2.1.0",
@@ -1815,7 +1815,6 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1901,7 +1900,6 @@
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -2253,7 +2251,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -2304,7 +2301,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3082,7 +3078,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3143,7 +3138,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3422,7 +3416,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4266,7 +4259,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -5023,7 +5015,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5945,7 +5936,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6598,7 +6588,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6700,7 +6689,6 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -6837,7 +6825,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6851,7 +6838,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -7108,7 +7094,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@actual-app/api": "25.11.0",
+    "@actual-app/api": "26.1.0",
     "@modelcontextprotocol/sdk": "1.17.4",
+    "dotenv": "17.2.3",
     "express": "5.2.1",
     "zod": "3.25.76",
-    "zod-to-json-schema": "3.25.0",
-    "dotenv": "17.2.3"
+    "zod-to-json-schema": "3.25.0"
   },
   "devDependencies": {
     "@changesets/cli": "2.29.8",

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -96,7 +96,7 @@ export async function getAccounts(): Promise<APIAccountEntity[]> {
 /**
  * Get all categories (ensures API is initialized)
  */
-export async function getCategories(): Promise<APICategoryEntity[]> {
+export async function getCategories(): Promise<(APICategoryEntity | APICategoryGroupEntity)[]> {
   await initActualApi();
   return api.getCategories();
 }
@@ -142,21 +142,21 @@ export async function getRules(): Promise<RuleEntity[]> {
  */
 export async function createPayee(args: Record<string, unknown>): Promise<string> {
   await initActualApi();
-  return api.createPayee(args);
+  return api.createPayee(args as Omit<APIPayeeEntity, 'id'>);
 }
 
 /**
  * Update a payee (ensures API is initialized)
  */
-export async function updatePayee(id: string, args: Record<string, unknown>): Promise<unknown> {
+export async function updatePayee(id: string, args: Record<string, unknown>): Promise<void> {
   await initActualApi();
-  return api.updatePayee(id, args);
+  return api.updatePayee(id, args as Partial<APIPayeeEntity>);
 }
 
 /**
  * Delete a payee (ensures API is initialized)
  */
-export async function deletePayee(id: string): Promise<unknown> {
+export async function deletePayee(id: string): Promise<void> {
   await initActualApi();
   return api.deletePayee(id);
 }
@@ -166,7 +166,7 @@ export async function deletePayee(id: string): Promise<unknown> {
  */
 export async function createRule(args: Record<string, unknown>): Promise<RuleEntity> {
   await initActualApi();
-  return api.createRule(args);
+  return api.createRule(args as Omit<RuleEntity, 'id'>);
 }
 
 /**
@@ -174,7 +174,7 @@ export async function createRule(args: Record<string, unknown>): Promise<RuleEnt
  */
 export async function updateRule(args: Record<string, unknown>): Promise<RuleEntity> {
   await initActualApi();
-  return api.updateRule(args);
+  return api.updateRule(args as RuleEntity);
 }
 
 /**
@@ -190,7 +190,7 @@ export async function deleteRule(id: string): Promise<boolean> {
  */
 export async function createCategory(args: Record<string, unknown>): Promise<string> {
   await initActualApi();
-  return api.createCategory(args);
+  return api.createCategory(args as Omit<APICategoryEntity, 'id'>);
 }
 
 /**
@@ -198,13 +198,13 @@ export async function createCategory(args: Record<string, unknown>): Promise<str
  */
 export async function updateCategory(id: string, args: Record<string, unknown>): Promise<unknown> {
   await initActualApi();
-  return api.updateCategory(id, args);
+  return api.updateCategory(id, args as Partial<APICategoryEntity>);
 }
 
 /**
  * Delete a category (ensures API is initialized)
  */
-export async function deleteCategory(id: string): Promise<{ error?: string }> {
+export async function deleteCategory(id: string): Promise<unknown> {
   await initActualApi();
   return api.deleteCategory(id);
 }
@@ -214,21 +214,21 @@ export async function deleteCategory(id: string): Promise<{ error?: string }> {
  */
 export async function createCategoryGroup(args: Record<string, unknown>): Promise<string> {
   await initActualApi();
-  return api.createCategoryGroup(args);
+  return api.createCategoryGroup(args as Omit<APICategoryGroupEntity, 'id'>);
 }
 
 /**
  * Update a category group (ensures API is initialized)
  */
-export async function updateCategoryGroup(id: string, args: Record<string, unknown>): Promise<unknown> {
+export async function updateCategoryGroup(id: string, args: Record<string, unknown>): Promise<void> {
   await initActualApi();
-  return api.updateCategoryGroup(id, args);
+  return api.updateCategoryGroup(id, args as Partial<APICategoryGroupEntity>);
 }
 
 /**
  * Delete a category group (ensures API is initialized)
  */
-export async function deleteCategoryGroup(id: string): Promise<unknown> {
+export async function deleteCategoryGroup(id: string): Promise<void> {
   await initActualApi();
   return api.deleteCategoryGroup(id);
 }
@@ -246,13 +246,13 @@ export async function createTransaction(accountId: string, data: TransactionData
  */
 export async function updateTransaction(id: string, data: UpdateTransactionData): Promise<unknown> {
   await initActualApi();
-  return api.updateTransaction(id, data);
+  return api.updateTransaction(id, data as Partial<TransactionEntity>);
 }
 
 /**
  * Delete a transaction (ensures API is initialized)
  */
-export async function deleteTransaction(id: string): Promise<unknown> {
+export async function deleteTransaction(id: string): Promise<TransactionEntity[]> {
   await initActualApi();
   return api.deleteTransaction(id);
 }

--- a/src/core/data/fetch-categories.ts
+++ b/src/core/data/fetch-categories.ts
@@ -2,7 +2,8 @@ import { getCategories, getCategoryGroups } from '../../actual-api.js';
 import type { Category, CategoryGroup } from '../types/domain.js';
 
 export async function fetchAllCategories(): Promise<Category[]> {
-  return getCategories();
+  const all = await getCategories();
+  return all.filter((item): item is Category => 'group_id' in item);
 }
 
 export async function fetchAllCategoryGroups(): Promise<CategoryGroup[]> {


### PR DESCRIPTION
## Summary

- Updates `@actual-app/api` from `25.11.0` to `26.1.0` to fix `"No budget file is open"` error when the Actual Budget server has applied newer database migrations than the bundled API client supports
- Adjusts type signatures in `actual-api.ts` to match the updated API (stricter parameter types, `getCategories()` now returns a union of categories and groups)
- Filters category groups from `fetchAllCategories()` since the API now returns both categories and groups from `getCategories()`

## Problem

When connecting to an Actual Budget server running a version newer than what `@actual-app/api@25.11.0` supports, `downloadBudget()` encounters `out-of-sync-migrations`. The error is logged but not thrown, so `initActualApi()` sets `initialized = true` even though no budget is actually open. All subsequent API calls then fail with:

```
{ type: 'APIError', message: 'No budget file is open' }
```

## Test plan

- [x] Verified `--test-resources` succeeds against a server with newer migrations (previously failed)
- [x] Build passes (`npm run build`)
- [x] All unit tests pass (2 pre-existing failures in `transaction-aggregator.test.ts` are unrelated)