### PR TITLE
fix: Handling concurrent SSE connections

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,29 +20,11 @@ import { randomUUID } from 'node:crypto';
 import { parseArgs } from 'node:util';
 import { initActualApi, shutdownActualApi } from './actual-api.js';
 import { fetchAllAccounts } from './core/data/fetch-accounts.js';
-import { setupPrompts } from './prompts.js';
-import { setupResources } from './resources.js';
-import { setupTools } from './tools/index.js';
-import { SetLevelRequestSchema, isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { createServer } from './server.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 
 // Reason: dotenv@17 (dotenvx) prints to stdout by default, which breaks MCP stdio JSON parsing
 dotenv.config({ path: '.env', quiet: true } as Parameters<typeof dotenv.config>[0]);
-
-// Initialize the MCP server
-const server = new Server(
-  {
-    name: 'Actual Budget',
-    version: '1.0.0',
-  },
-  {
-    capabilities: {
-      resources: {},
-      tools: {},
-      prompts: {},
-      logging: {},
-    },
-  }
-);
 
 // Argument parsing
 const {
@@ -179,16 +161,17 @@ async function main(): Promise<void> {
   if (useSse) {
     const app = express();
     app.use(express.json());
-    let transport: SSEServerTransport | null = null;
 
     // Log bearer auth status
     if (enableBearer) {
-      console.error('Bearer authentication enabled for SSE endpoints');
+      process.stderr.write('Bearer authentication enabled for SSE endpoints\n');
     } else {
-      console.error('Bearer authentication disabled - endpoints are public');
+      process.stderr.write('Bearer authentication disabled - endpoints are public\n');
     }
 
-    const streamableHttpTransports = new Map<string, StreamableHTTPServerTransport>();
+    // Per-connection maps for legacy SSE and streamable HTTP
+    const legacySseConnections = new Map<string, { server: Server; transport: SSEServerTransport }>();
+    const streamableSessions = new Map<string, { server: Server; transport: StreamableHTTPServerTransport }>();
 
     const parseSessionHeader = (value: string | string[] | undefined): string | undefined => {
       if (!value) {
@@ -204,14 +187,19 @@ async function main(): Promise<void> {
       res.status(404).json({ error: 'OAuth metadata not configured for this server' });
     });
 
-    const handleLegacySse = (req: Request, res: Response): void => {
-      transport = new SSEServerTransport('/messages', res);
-      server.connect(transport).then(() => {
-        console.log = (message: string) => server.sendLoggingMessage({ level: 'info', data: message });
+    const handleLegacySse = (_req: Request, res: Response): void => {
+      const connectionId = randomUUID();
+      const connServer = createServer({ enableWrite: !!enableWrite });
+      const sseTransport = new SSEServerTransport(`/messages?connectionId=${connectionId}`, res);
+      legacySseConnections.set(connectionId, { server: connServer, transport: sseTransport });
 
-        console.error = (message: string) => server.sendLoggingMessage({ level: 'error', data: message });
+      connServer.connect(sseTransport).then(() => {
+        process.stderr.write(`Legacy SSE connection established (connectionId ${connectionId})\n`);
+      });
 
-        console.error(`Actual Budget MCP Server (SSE) started on port ${resolvedPort}`);
+      res.on('close', () => {
+        legacySseConnections.delete(connectionId);
+        connServer.close();
       });
     };
 
@@ -227,41 +215,39 @@ async function main(): Promise<void> {
       }
       const requestLabel = `${req.method} ${req.path}`;
       try {
-        let streamableTransport = sessionHeader ? streamableHttpTransports.get(sessionHeader) : undefined;
+        let session = sessionHeader ? streamableSessions.get(sessionHeader) : undefined;
 
-        if (!streamableTransport) {
+        if (!session) {
           if (req.method === 'POST' && isInitializeRequest(req.body)) {
             const remoteAddress = req.ip ?? req.socket.remoteAddress ?? 'unknown';
-            streamableTransport = new StreamableHTTPServerTransport({
+            const sessionServer = createServer({ enableWrite: !!enableWrite });
+            const streamableTransport = new StreamableHTTPServerTransport({
               sessionIdGenerator: () => randomUUID(),
               onsessioninitialized: (sessionId) => {
-                streamableHttpTransports.set(sessionId, streamableTransport!);
+                streamableSessions.set(sessionId, { server: sessionServer, transport: streamableTransport });
                 console.info(`Streamable HTTP session initialized (session ${sessionId}) from ${remoteAddress}`);
               },
               onsessionclosed: (sessionId) => {
-                streamableHttpTransports.delete(sessionId);
+                streamableSessions.delete(sessionId);
+                sessionServer.close();
                 console.info(`Streamable HTTP session closed (session ${sessionId})`);
               },
             });
 
             streamableTransport.onclose = () => {
-              const activeSessionId = streamableTransport?.sessionId;
+              const activeSessionId = streamableTransport.sessionId;
               if (activeSessionId) {
-                streamableHttpTransports.delete(activeSessionId);
+                streamableSessions.delete(activeSessionId);
+                sessionServer.close();
                 console.info(`Streamable HTTP transport closed (session ${activeSessionId})`);
               }
             };
 
             try {
-              await server.connect(streamableTransport);
-
-              console.log = (message: string) => server.sendLoggingMessage({ level: 'info', data: message });
-
-              console.error = (message: string) => server.sendLoggingMessage({ level: 'error', data: message });
-
-              console.error(`Actual Budget MCP Server (Streamable HTTP) started on port ${resolvedPort}`);
+              await sessionServer.connect(streamableTransport);
+              process.stderr.write(`Actual Budget MCP Server (Streamable HTTP) started on port ${resolvedPort}\n`);
             } catch (error) {
-              console.error(`Failed to connect streamable HTTP transport: ${toErrorMessage(error)}`);
+              process.stderr.write(`Failed to connect streamable HTTP transport: ${toErrorMessage(error)}\n`);
               res.status(500).json({
                 jsonrpc: '2.0',
                 error: {
@@ -272,6 +258,8 @@ async function main(): Promise<void> {
               });
               return;
             }
+
+            session = { server: sessionServer, transport: streamableTransport };
           } else {
             res.status(400).json({
               jsonrpc: '2.0',
@@ -285,21 +273,9 @@ async function main(): Promise<void> {
           }
         }
 
-        if (!streamableTransport) {
-          res.status(500).json({
-            jsonrpc: '2.0',
-            error: {
-              code: -32603,
-              message: 'Internal server error',
-            },
-            id: null,
-          });
-          return;
-        }
-
-        await streamableTransport.handleRequest(req, res, req.body);
+        await session.transport.handleRequest(req, res, req.body);
       } catch (error) {
-        console.error(`Streamable HTTP handler error for ${requestLabel}: ${toErrorMessage(error)}`);
+        process.stderr.write(`Streamable HTTP handler error for ${requestLabel}: ${toErrorMessage(error)}\n`);
 
         if (!res.headersSent) {
           res.status(500).json({
@@ -315,59 +291,49 @@ async function main(): Promise<void> {
     });
 
     app.post('/messages', bearerAuth, async (req: Request, res: Response) => {
-      if (transport) {
-        await transport.handlePostMessage(req, res, req.body);
+      const connectionId = req.query.connectionId as string | undefined;
+      const conn = connectionId ? legacySseConnections.get(connectionId) : undefined;
+      if (conn) {
+        await conn.transport.handlePostMessage(req, res, req.body);
       } else {
-        res.status(500).json({ error: 'Transport not initialized' });
+        res.status(400).json({ error: 'Invalid or missing connectionId' });
       }
     });
 
     app.listen(resolvedPort, (error) => {
       if (error) {
-        console.error('Error:', error);
+        process.stderr.write(`Error: ${toErrorMessage(error)}\n`);
       } else {
-        console.error(`Actual Budget MCP Server (SSE) started on port ${resolvedPort}`);
+        process.stderr.write(`Actual Budget MCP Server (HTTP) listening on port ${resolvedPort}\n`);
       }
     });
+    // SIGINT handler: close all active connections
+    process.on('SIGINT', () => {
+      process.stderr.write('SIGINT received, shutting down server\n');
+      for (const [, conn] of legacySseConnections) {
+        conn.server.close();
+      }
+      for (const [, session] of streamableSessions) {
+        session.server.close();
+        session.transport.close();
+      }
+      process.exit(0);
+    });
   } else {
+    const server = createServer({ enableWrite: !!enableWrite });
     const transport = new StdioServerTransport();
     await server.connect(transport);
     console.error('Actual Budget MCP Server (stdio) started');
+
+    process.on('SIGINT', () => {
+      console.error('SIGINT received, shutting down server');
+      server.close();
+      process.exit(0);
+    });
   }
 }
 
-setupResources(server);
-setupTools(server, enableWrite);
-setupPrompts(server);
-
-server.setRequestHandler(SetLevelRequestSchema, (request) => {
-  console.log(`--- Logging level: ${request.params.level}`);
-  return {};
+main().catch((error: unknown) => {
+  console.error(`Server error: ${toErrorMessage(error)}`);
+  process.exit(1);
 });
-
-process.on('SIGINT', () => {
-  console.error('SIGINT received, shutting down server');
-  server.close();
-  process.exit(0);
-});
-
-main()
-  .then(() => {
-    if (!useSse) {
-      // TODO: Setup proper logging level change. Messages are available in the notification of MCP Inspector
-      console.log = (message: string) =>
-        server.sendLoggingMessage({
-          level: 'info',
-          data: message,
-        });
-      console.error = (message: string) =>
-        server.sendLoggingMessage({
-          level: 'error',
-          data: message,
-        });
-    }
-  })
-  .catch((error: unknown) => {
-    console.error(`Server error: ${toErrorMessage(error)}`);
-    process.exit(1);
-  });

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,51 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { describe, expect, it, vi } from 'vitest';
+import { createServer } from './server.js';
+
+vi.mock('./resources.js', () => ({
+  setupResources: vi.fn(),
+}));
+
+vi.mock('./tools/index.js', () => ({
+  setupTools: vi.fn(),
+}));
+
+vi.mock('./prompts.js', () => ({
+  setupPrompts: vi.fn(),
+}));
+
+import { setupResources } from './resources.js';
+import { setupTools } from './tools/index.js';
+import { setupPrompts } from './prompts.js';
+
+describe('createServer', () => {
+  it('returns a configured Server instance', () => {
+    const server = createServer({ enableWrite: false });
+
+    expect(server).toBeInstanceOf(Server);
+    expect(setupResources).toHaveBeenCalledWith(server);
+    expect(setupTools).toHaveBeenCalledWith(server, false);
+    expect(setupPrompts).toHaveBeenCalledWith(server);
+  });
+
+  it('passes enableWrite: true to setupTools', () => {
+    vi.mocked(setupTools).mockClear();
+    const server = createServer({ enableWrite: true });
+
+    expect(setupTools).toHaveBeenCalledWith(server, true);
+  });
+
+  it('registers all setup handlers for each new instance', () => {
+    vi.mocked(setupResources).mockClear();
+    vi.mocked(setupTools).mockClear();
+    vi.mocked(setupPrompts).mockClear();
+
+    const server1 = createServer({ enableWrite: false });
+    const server2 = createServer({ enableWrite: true });
+
+    expect(server1).not.toBe(server2);
+    expect(setupResources).toHaveBeenCalledTimes(2);
+    expect(setupTools).toHaveBeenCalledTimes(2);
+    expect(setupPrompts).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,43 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { setupPrompts } from './prompts.js';
+import { setupResources } from './resources.js';
+import { setupTools } from './tools/index.js';
+
+interface CreateServerOptions {
+  enableWrite: boolean;
+}
+
+/**
+ * Creates and configures a new MCP Server instance with all resources, tools, and prompts.
+ *
+ * @param options - Server configuration options
+ * @returns A fully configured Server instance ready to be connected to a transport
+ */
+export function createServer(options: CreateServerOptions): Server {
+  const server = new Server(
+    {
+      name: 'Actual Budget',
+      version: '1.0.0',
+    },
+    {
+      capabilities: {
+        resources: {},
+        tools: {},
+        prompts: {},
+        logging: {},
+      },
+    }
+  );
+
+  setupResources(server);
+  setupTools(server, options.enableWrite);
+  setupPrompts(server);
+
+  server.setRequestHandler(SetLevelRequestSchema, (request) => {
+    process.stderr.write(`--- Logging level: ${request.params.level}\n`);
+    return {};
+  });
+
+  return server;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     environment: 'node',
-    include: ['src/core/**/*.test.ts', 'src/tools/**/*.test.ts'],
+    include: ['src/**/*.test.ts'],
     globals: true,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Previously, a single global Server instance was shared across all HTTP/SSE connections. When multiple clients connected simultaneously, they would overwrite each other's transports and console overrides, causing crashes.

- Extract createServer() factory into src/server.ts
- Legacy SSE: each connection gets its own Server + SSEServerTransport, routed via connectionId query param
- Streamable HTTP: each session gets its own Server + transport pair
- Replace global console.log/error overrides with process.stderr.write in HTTP mode to eliminate race conditions
- Keep stdio mode unchanged (single connection, safe to override console)

Addresses - #135