### PR TITLE
fix: create counterpart transaction for transfers by enabling runTransfers

### DIFF
--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -241,11 +241,12 @@ export async function deleteCategoryGroup(id: string): Promise<unknown> {
 }
 
 /**
- * Create a transaction (ensures API is initialized)
+ * Create a transaction (ensures API is initialized).
+ * Passes runTransfers so that transfer payees automatically create the counterpart transaction.
  */
 export async function createTransaction(accountId: string, data: TransactionData): Promise<string> {
   await initActualApi();
-  return api.addTransactions(accountId, [data]);
+  return api.addTransactions(accountId, [data], { runTransfers: true });
 }
 
 /**

--- a/src/tools/create-transaction/index.test.ts
+++ b/src/tools/create-transaction/index.test.ts
@@ -11,6 +11,7 @@ import { textContent } from '../../utils/response.js';
 // Mock the actual-api module
 vi.mock('../../actual-api.js', () => ({
   createTransaction: vi.fn(),
+  getPayees: vi.fn(),
 }));
 
 describe('create-transaction tool', () => {
@@ -21,7 +22,7 @@ describe('create-transaction tool', () => {
   describe('schema', () => {
     it('should have correct tool name and description', () => {
       expect(schema.name).toBe('create-transaction');
-      expect(schema.description).toBe('Create a new transaction. Use this to add transactions to accounts.');
+      expect(schema.description).toContain('Create a new transaction');
     });
 
     it('should require account, date, and amount fields', () => {
@@ -39,6 +40,7 @@ describe('create-transaction tool', () => {
       expect(properties).toHaveProperty('notes');
       expect(properties).toHaveProperty('cleared');
       expect(properties).toHaveProperty('subtransactions');
+      expect(properties).toHaveProperty('transfer_account_id');
     });
   });
 
@@ -118,6 +120,81 @@ describe('create-transaction tool', () => {
         ],
       });
       expect(result.isError).toBeUndefined();
+    });
+  });
+
+  describe('handler - transfer cases', () => {
+    it('should resolve transfer payee and create transfer transaction', async () => {
+      const mockTransactionId = 'transfer-txn-1';
+      vi.mocked(actualApi.getPayees).mockResolvedValue([
+        { id: 'payee-savings', name: 'Transfer: Savings', transfer_acct: 'savings-account-id' },
+        { id: 'payee-checking', name: 'Transfer: Checking', transfer_acct: 'checking-account-id' },
+      ]);
+      vi.mocked(actualApi.createTransaction).mockResolvedValue(mockTransactionId);
+
+      const args: CreateTransactionArgs = {
+        account: 'checking-account-id',
+        date: '2025-12-18',
+        amount: -5000,
+        transfer_account_id: 'savings-account-id',
+      };
+
+      const result = await handler(args);
+
+      expect(actualApi.getPayees).toHaveBeenCalled();
+      expect(actualApi.createTransaction).toHaveBeenCalledWith('checking-account-id', {
+        date: '2025-12-18',
+        amount: -5000,
+        payee: 'payee-savings',
+      });
+      expect(result.isError).toBeUndefined();
+      expect(textContent(result.content[0])).toContain('transfer');
+      expect(textContent(result.content[0])).toContain('counterpart');
+    });
+
+    it('should override payee with transfer payee when transfer_account_id is provided', async () => {
+      const mockTransactionId = 'transfer-txn-2';
+      vi.mocked(actualApi.getPayees).mockResolvedValue([
+        { id: 'payee-savings', name: 'Transfer: Savings', transfer_acct: 'savings-account-id' },
+      ]);
+      vi.mocked(actualApi.createTransaction).mockResolvedValue(mockTransactionId);
+
+      const args: CreateTransactionArgs = {
+        account: 'checking-account-id',
+        date: '2025-12-18',
+        amount: -5000,
+        payee: 'some-other-payee',
+        transfer_account_id: 'savings-account-id',
+      };
+
+      const result = await handler(args);
+
+      // transfer_account_id should override the payee
+      expect(actualApi.createTransaction).toHaveBeenCalledWith('checking-account-id', {
+        date: '2025-12-18',
+        amount: -5000,
+        payee: 'payee-savings',
+      });
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should return error when transfer payee is not found', async () => {
+      vi.mocked(actualApi.getPayees).mockResolvedValue([
+        { id: 'payee-checking', name: 'Transfer: Checking', transfer_acct: 'checking-account-id' },
+      ]);
+
+      const args: CreateTransactionArgs = {
+        account: 'checking-account-id',
+        date: '2025-12-18',
+        amount: -5000,
+        transfer_account_id: 'nonexistent-account-id',
+      };
+
+      const result = await handler(args);
+
+      expect(result.isError).toBe(true);
+      expect(textContent(result.content[0])).toContain('No transfer payee found');
+      expect(actualApi.createTransaction).not.toHaveBeenCalled();
     });
   });
 

--- a/src/tools/create-transaction/index.ts
+++ b/src/tools/create-transaction/index.ts
@@ -4,26 +4,53 @@
 
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { toJSONSchema } from 'zod';
-import { successWithJson, errorFromCatch } from '../../utils/response.js';
-import { createTransaction } from '../../actual-api.js';
+import { successWithJson, errorFromCatch, error } from '../../utils/response.js';
+import { createTransaction, getPayees } from '../../actual-api.js';
 import { CreateTransactionArgsSchema, type CreateTransactionArgs, ToolInput } from '../../types.js';
 
 export const schema = {
   name: 'create-transaction',
-  description: 'Create a new transaction. Use this to add transactions to accounts.',
+  description:
+    'Create a new transaction. Use this to add transactions to accounts. Supports transfers between accounts by specifying transfer_account_id.',
   inputSchema: toJSONSchema(CreateTransactionArgsSchema) as ToolInput,
 };
+
+/**
+ * Resolve the transfer payee ID for a given destination account.
+ * Each account in Actual has a corresponding payee with transfer_acct set.
+ */
+async function resolveTransferPayee(destinationAccountId: string): Promise<string | null> {
+  const payees = await getPayees();
+  const transferPayee = payees.find((p) => p.transfer_acct === destinationAccountId);
+  return transferPayee?.id ?? null;
+}
 
 export async function handler(args: CreateTransactionArgs): Promise<CallToolResult> {
   try {
     // Validate with Zod schema
     const validatedArgs = CreateTransactionArgsSchema.parse(args);
 
-    const { account: accountId, ...transactionData } = validatedArgs;
+    const { account: accountId, transfer_account_id, ...transactionData } = validatedArgs;
+
+    // Reason: When transfer_account_id is provided, look up the transfer payee
+    // so that addTransactions (with runTransfers: true) creates the counterpart automatically.
+    if (transfer_account_id) {
+      const transferPayeeId = await resolveTransferPayee(transfer_account_id);
+      if (!transferPayeeId) {
+        return error(
+          `No transfer payee found for account ${transfer_account_id}. Ensure the destination account exists.`
+        );
+      }
+      transactionData.payee = transferPayeeId;
+    }
 
     const id: string = await createTransaction(accountId, transactionData);
 
-    return successWithJson('Successfully created transaction ' + id);
+    const message = transfer_account_id
+      ? `Successfully created transfer transaction ${id} (counterpart created in destination account)`
+      : `Successfully created transaction ${id}`;
+
+    return successWithJson(message);
   } catch (err) {
     return errorFromCatch(err);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,12 @@ export const CreateTransactionArgsSchema = z.object({
     .describe(
       'If a transfer, the id of the corresponding transaction in the other account. Only set this when importing'
     ),
+  transfer_account_id: z
+    .string()
+    .optional()
+    .describe(
+      'The ID of the destination account for a transfer. When provided, the transfer payee is automatically resolved and the counterpart transaction is created in the destination account. The amount should be negative (money leaving the source account).'
+    ),
   cleared: z.boolean().optional().describe('A flag indicating if the transaction has cleared or not'),
   subtransactions: z
     .array(SubtransactionSchema)
@@ -177,8 +183,8 @@ export const CreateTransactionArgsSchema = z.object({
 
 export type CreateTransactionArgs = z.infer<typeof CreateTransactionArgsSchema>;
 
-// Schema for transaction data passed to the API (without account, which is passed separately)
-export const TransactionDataSchema = CreateTransactionArgsSchema.omit({ account: true });
+// Schema for transaction data passed to the API (without account and transfer_account_id, which are handled separately)
+export const TransactionDataSchema = CreateTransactionArgsSchema.omit({ account: true, transfer_account_id: true });
 export type TransactionData = z.infer<typeof TransactionDataSchema>;
 
 // Subtransaction schema for imports — amount is a decimal (e.g. 3.24), converted to integer by the API wrapper


### PR DESCRIPTION
Fixes #138

## Summary
- Pass `{ runTransfers: true }` to `api.addTransactions()` so transfer payees automatically create the counterpart transaction in the destination account
- Add `transfer_account_id` convenience parameter to `create-transaction` tool — auto-resolves the internal transfer payee so users don't need to know the payee ID
- Handler looks up the payee where `transfer_acct` matches the destination account and sets it before calling the API