### PR TITLE
feat(tools): add make-transfer tool to link existing transactions as …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1483,6 +1483,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -1855,6 +1856,7 @@
       "integrity": "sha512-/irhyeAcKS2u6Zokagf9tqZJ0t8S6kMZq4ZG9BHZv7I+fkRrYfQX4w7geYeC2r6obThz39PDxvXQzZX+qXqGeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.2",
         "fflate": "^0.8.2",
@@ -1905,6 +1907,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2549,6 +2552,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2609,6 +2613,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -2808,6 +2813,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3217,6 +3223,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.4.tgz",
       "integrity": "sha512-ooiZW1Xy8rQ4oELQ++otI2T9DsKpV0M6c6cO6JGx4RTfav9poFFLlet9UMXHZnoM1yG0HWGlQLswBGX3RZmHtg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3441,6 +3448,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3943,6 +3951,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4031,6 +4040,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5261,6 +5271,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5353,6 +5364,7 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -5461,6 +5473,7 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -5612,6 +5625,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -279,6 +279,53 @@ export async function deleteTransaction(id: string): Promise<unknown> {
 }
 
 /**
+ * Fetch a single transaction by id using the internal DB accessor.
+ *
+ * Reason: the public API only exposes account-scoped range fetching, but
+ * linking two existing transactions as a transfer requires loading each
+ * transaction by id directly.
+ */
+export async function getTransactionById(id: string): Promise<TransactionEntity | null> {
+  await initActualApi();
+  const row = (await api.internal.db.getTransaction(id)) as TransactionEntity | null;
+  return row ?? null;
+}
+
+/**
+ * Link two existing transactions as a transfer pair.
+ *
+ * Mirrors the desktop client's "Make Transfer" batch action: updates both
+ * transactions' payee and transfer_id fields in a single batch with
+ * runTransfers: false to prevent the transfer subsystem from creating
+ * duplicate counterparts.
+ */
+export async function makeTransfer(
+  fromTransaction: TransactionEntity,
+  toTransaction: TransactionEntity,
+  fromTransferPayeeId: string,
+  toTransferPayeeId: string
+): Promise<unknown> {
+  await initActualApi();
+  return api.internal.send('transactions-batch-update', {
+    updated: [
+      {
+        ...fromTransaction,
+        category: null,
+        payee: toTransferPayeeId,
+        transfer_id: toTransaction.id,
+      },
+      {
+        ...toTransaction,
+        category: null,
+        payee: fromTransferPayeeId,
+        transfer_id: fromTransaction.id,
+      },
+    ],
+    runTransfers: false,
+  });
+}
+
+/**
  * Run bank sync for accounts (ensures API is initialized)
  *
  * @param accountId - Optional. Specific account ID, or special value:

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -31,6 +31,7 @@ import * as deleteTransaction from './delete-transaction/index.js';
 import * as updateTransaction from './update-transaction/index.js';
 import * as createTransaction from './create-transaction/index.js';
 import * as importTransactions from './import-transactions/index.js';
+import * as makeTransfer from './make-transfer/index.js';
 import * as runBankSync from './run-bank-sync/index.js';
 
 const readTools = [
@@ -61,6 +62,7 @@ const writeTools = [
   deleteTransaction,
   createTransaction,
   importTransactions,
+  makeTransfer,
   runBankSync,
 ];
 

--- a/src/tools/make-transfer/index.test.ts
+++ b/src/tools/make-transfer/index.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+// CRITICAL: Mock before imports
+vi.mock('../../actual-api.js', () => ({
+  getTransactionById: vi.fn(),
+  getPayees: vi.fn(),
+  makeTransfer: vi.fn(),
+}));
+
+import { getTransactionById, getPayees, makeTransfer } from '../../actual-api.js';
+
+const accountA = 'acc-aaa';
+const accountB = 'acc-bbb';
+const fromPayeeId = 'payee-transfer-A';
+const toPayeeId = 'payee-transfer-B';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function tx(overrides: Record<string, unknown> = {}): any {
+  return {
+    id: 'tx',
+    account: accountA,
+    amount: -5000,
+    date: '2024-01-15',
+    transfer_id: null,
+    payee: 'some-payee',
+    notes: null,
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('make-transfer tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getPayees).mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: fromPayeeId, name: 'Account A', transfer_acct: accountA } as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: toPayeeId, name: 'Account B', transfer_acct: accountB } as any,
+    ]);
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('make-transfer');
+      expect(schema.description).toContain('transfer');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should link two valid transactions as a transfer', async () => {
+      const fromTx = tx({ id: 'from', account: accountA, amount: -5000 });
+      const toTx = tx({ id: 'to', account: accountB, amount: 5000 });
+      vi.mocked(getTransactionById).mockImplementation(async (id) => (id === 'from' ? fromTx : toTx));
+      vi.mocked(makeTransfer).mockResolvedValue({});
+
+      const result = await handler({ fromId: 'from', toId: 'to' });
+
+      expect(result.isError).toBeUndefined();
+      expect(makeTransfer).toHaveBeenCalledWith(fromTx, toTx, fromPayeeId, toPayeeId);
+      expect((result.content[0] as { text: string }).text).toContain('Successfully linked');
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should reject when fromId equals toId', async () => {
+      const result = await handler({ fromId: 'same', toId: 'same' });
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('must be different');
+      expect(getTransactionById).not.toHaveBeenCalled();
+    });
+
+    it('should reject when fromId missing', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await handler({ toId: 'to' } as any);
+      expect(result.isError).toBe(true);
+    });
+
+    it('should reject when a transaction is not found', async () => {
+      vi.mocked(getTransactionById).mockImplementation(async (id) =>
+        id === 'from' ? tx({ id: 'from', account: accountA, amount: -5000 }) : null
+      );
+
+      const result = await handler({ fromId: 'from', toId: 'missing' });
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('not found');
+      expect(makeTransfer).not.toHaveBeenCalled();
+    });
+
+    it('should reject transactions in the same account', async () => {
+      vi.mocked(getTransactionById).mockImplementation(async (id) =>
+        tx({ id, account: accountA, amount: id === 'from' ? -5000 : 5000 })
+      );
+
+      const result = await handler({ fromId: 'from', toId: 'to' });
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('same account');
+      expect(makeTransfer).not.toHaveBeenCalled();
+    });
+
+    it('should reject transactions whose amounts do not cancel out', async () => {
+      vi.mocked(getTransactionById).mockImplementation(async (id) =>
+        id === 'from'
+          ? tx({ id: 'from', account: accountA, amount: -5000 })
+          : tx({ id: 'to', account: accountB, amount: 6000 })
+      );
+
+      const result = await handler({ fromId: 'from', toId: 'to' });
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('do not cancel');
+      expect(makeTransfer).not.toHaveBeenCalled();
+    });
+
+    it('should reject when a transaction is already part of a transfer', async () => {
+      vi.mocked(getTransactionById).mockImplementation(async (id) =>
+        id === 'from'
+          ? tx({ id: 'from', account: accountA, amount: -5000, transfer_id: 'existing' })
+          : tx({ id: 'to', account: accountB, amount: 5000 })
+      );
+
+      const result = await handler({ fromId: 'from', toId: 'to' });
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('already part of a transfer');
+      expect(makeTransfer).not.toHaveBeenCalled();
+    });
+
+    it('should reject when destination account has no transfer payee', async () => {
+      vi.mocked(getTransactionById).mockImplementation(async (id) =>
+        id === 'from'
+          ? tx({ id: 'from', account: accountA, amount: -5000 })
+          : tx({ id: 'to', account: 'acc-unknown', amount: 5000 })
+      );
+
+      const result = await handler({ fromId: 'from', toId: 'to' });
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('No transfer payee');
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should surface errors from makeTransfer', async () => {
+      vi.mocked(getTransactionById).mockImplementation(async (id) =>
+        id === 'from'
+          ? tx({ id: 'from', account: accountA, amount: -5000 })
+          : tx({ id: 'to', account: accountB, amount: 5000 })
+      );
+      vi.mocked(makeTransfer).mockRejectedValue(new Error('batch update failed'));
+
+      const result = await handler({ fromId: 'from', toId: 'to' });
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('batch update failed');
+    });
+  });
+});

--- a/src/tools/make-transfer/index.ts
+++ b/src/tools/make-transfer/index.ts
@@ -1,0 +1,69 @@
+// ----------------------------
+// MAKE TRANSFER TOOL
+// ----------------------------
+
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { toJSONSchema } from 'zod';
+import { success, errorFromCatch, error } from '../../utils/response.js';
+import { getTransactionById, getPayees, makeTransfer } from '../../actual-api.js';
+import { MakeTransferArgsSchema, type MakeTransferArgs, ToolInput } from '../../types.js';
+
+export const schema = {
+  name: 'make-transfer',
+  description:
+    'Link two existing transactions as a transfer pair. Equivalent to the "Make Transfer" action in the Actual Budget UI: ' +
+    'updates both transactions to reference each other via transfer_id and sets the appropriate transfer payees. ' +
+    'The two transactions must be in different accounts, have amounts that sum to zero, and neither may already be part of a transfer.',
+  inputSchema: toJSONSchema(MakeTransferArgsSchema) as ToolInput,
+};
+
+export async function handler(args: MakeTransferArgs): Promise<CallToolResult> {
+  try {
+    const { fromId, toId } = MakeTransferArgsSchema.parse(args);
+
+    if (fromId === toId) {
+      return error('fromId and toId must be different transactions.');
+    }
+
+    const [fromTx, toTx] = await Promise.all([getTransactionById(fromId), getTransactionById(toId)]);
+
+    if (!fromTx) {
+      return error(`Transaction not found: ${fromId}`);
+    }
+    if (!toTx) {
+      return error(`Transaction not found: ${toId}`);
+    }
+
+    // Reason: validation mirrors loot-core/shared/transfer.ts `validForTransfer`.
+    // Both must be in different accounts, amounts must cancel out, and neither
+    // can already be part of an existing transfer pair.
+    if (fromTx.account === toTx.account) {
+      return error('Both transactions are in the same account. A transfer requires two different accounts.');
+    }
+    if (fromTx.amount + toTx.amount !== 0) {
+      return error(
+        `Transaction amounts do not cancel out (${fromTx.amount} + ${toTx.amount} = ${fromTx.amount + toTx.amount}). A transfer requires opposite amounts.`
+      );
+    }
+    if (fromTx.transfer_id != null || toTx.transfer_id != null) {
+      return error('One or both transactions are already part of a transfer. Unlink them first before re-linking.');
+    }
+
+    const payees = await getPayees();
+    const fromTransferPayee = payees.find((p) => p.transfer_acct === fromTx.account);
+    const toTransferPayee = payees.find((p) => p.transfer_acct === toTx.account);
+
+    if (!fromTransferPayee) {
+      return error(`No transfer payee found for account ${fromTx.account}.`);
+    }
+    if (!toTransferPayee) {
+      return error(`No transfer payee found for account ${toTx.account}.`);
+    }
+
+    await makeTransfer(fromTx, toTx, fromTransferPayee.id, toTransferPayee.id);
+
+    return success(`Successfully linked transactions ${fromId} and ${toId} as a transfer pair.`);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,6 +246,13 @@ export const ImportTransactionItemSchema = z.object({
 
 export type ImportTransactionItem = z.infer<typeof ImportTransactionItemSchema>;
 
+export const MakeTransferArgsSchema = z.object({
+  fromId: z.string().describe('Required. The ID of the first transaction in the transfer pair (usually the outflow).'),
+  toId: z.string().describe('Required. The ID of the second transaction in the transfer pair (usually the inflow).'),
+});
+
+export type MakeTransferArgs = z.infer<typeof MakeTransferArgsSchema>;
+
 export const ImportTransactionsArgsSchema = z.object({
   accountId: z.string().describe('Required. The ID of the account to import transactions into'),
   transactions: z


### PR DESCRIPTION
…transfer pair

Mirrors the Actual Budget UI "Make Transfer" action: validates that two transactions are in different accounts with amounts that cancel out and neither already part of a transfer, then updates both via a batch send to set transfer_id and transfer payees.