### PR TITLE
feat: add budget endpoints (getBudgetMonths, getBudgetMonth, setBudgetAmount, setBudgetCarryover, holdBudgetForNextMonth, resetBudgetHold)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.11.2",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/api": "^26.2.1",
+        "@actual-app/api": "^26.4.0",
         "@modelcontextprotocol/sdk": "1.27.1",
         "dotenv": "17.3.1",
         "express": "5.2.1",
@@ -38,19 +38,49 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "26.2.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.2.1.tgz",
-      "integrity": "sha512-oTgtVm0rhJBrDasCOAtgNxyFWoTyiQGGeaDYNIAgTq9uHJtUp7z7knA24ktFrMxEf3Jc92M0U393qnbrYTrv8g==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.4.0.tgz",
+      "integrity": "sha512-U0uRKiXy62nQ60QyVikdKP2QhGcwGOY1JL6AioN5BtkN+5liZ1Onn/TlAhpUZi18UJ5NpHRuW7zyz4/MfcoCEA==",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/crdt": "^2.1.0",
-        "better-sqlite3": "^12.5.0",
+        "@actual-app/core": "26.4.0",
+        "@actual-app/crdt": "2.1.0",
+        "better-sqlite3": "^12.6.2",
         "compare-versions": "^6.1.1",
         "node-fetch": "^3.3.2",
         "uuid": "^13.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@actual-app/core": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.4.0.tgz",
+      "integrity": "sha512-vhzQNZQs5Ejc63jD6hXvlPWjvDsBmI9ODR3Y7CfesY4XLFbu98DZJRrBpLAMPus+TkupcsLzDtAjWpX2htTLBw==",
+      "license": "ISC",
+      "dependencies": {
+        "@jlongster/sql.js": "^1.6.7",
+        "@reduxjs/toolkit": "^2.11.2",
+        "@rschedule/core": "^1.5.0",
+        "@rschedule/json-tools": "^1.5.0",
+        "@rschedule/standard-date-adapter": "^1.5.0",
+        "absurd-sql": "0.0.54",
+        "adm-zip": "^0.5.16",
+        "better-sqlite3": "^12.6.2",
+        "csv-parse": "^6.1.0",
+        "csv-stringify": "^6.6.0",
+        "date-fns": "^4.1.0",
+        "handlebars": "^4.7.9",
+        "lru-cache": "^11.2.6",
+        "md5": "^2.3.0",
+        "memoize-one": "^6.0.0",
+        "mitt": "^3.0.1",
+        "promise-retry": "^2.0.1",
+        "slash": "5.1.0",
+        "typescript-strict-plugin": "^2.4.4",
+        "ua-parser-js": "^2.0.9",
+        "uuid": "^13.0.0"
       }
     },
     "node_modules/@actual-app/crdt": {
@@ -834,6 +864,12 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jlongster/sql.js": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@jlongster/sql.js/-/sql.js-1.6.7.tgz",
+      "integrity": "sha512-4hf0kZr5WPoirdR5hUSfQ9O0JpH/qlW1CaR2wZ6zGrDz1xjSdTPuR8AW/oXzIHnJvZSEvlcIE+dfXJZwh/Lxfw==",
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -943,6 +979,32 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1294,11 +1356,40 @@
         "win32"
       ]
     },
+    "node_modules/@rschedule/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rschedule/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-uN6Kjx4dnpheesXx+wm0B3E+xJPCw3TdNFmNAIXj9oPVD5t4smbpu/IBPZIzfv8bf7I88s/ahDKkltU6W3H6dw==",
+      "license": "Unlicense"
+    },
+    "node_modules/@rschedule/json-tools": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rschedule/json-tools/-/json-tools-1.5.0.tgz",
+      "integrity": "sha512-vwqBc1qkkjE7JzU5wrgCNMBVBUJgWcA9t8zrFr6Dmtd/npEO2XRrKaH5zamFgwsl1O3xqk1Law6EbeH5TJ1RHQ==",
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@rschedule/core": "^1.5.0"
+      }
+    },
+    "node_modules/@rschedule/standard-date-adapter": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@rschedule/standard-date-adapter/-/standard-date-adapter-1.5.0.tgz",
+      "integrity": "sha512-gQUlCOmYVaGvq6IZT29VVl4uZhaauwgG9aWxXLvC7x3lSF1f+z52iLAj853Mc4a1UgXQtEwt7Wujb9twl740Ew==",
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@rschedule/core": "^1.5.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@types/body-parser": {
@@ -1886,6 +1977,14 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/absurd-sql": {
+      "version": "0.0.54",
+      "resolved": "https://registry.npmjs.org/absurd-sql/-/absurd-sql-0.0.54.tgz",
+      "integrity": "sha512-p+SWTtpRs2t3sXMLxkTyLRZkEzxTv/zG/Bl93wibegLZTGAHGk68SJMWslRWHBGh63ka/ePGTXGHh1117++45Q==",
+      "dependencies": {
+        "safari-14-idb-fix": "^1.0.4"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1920,6 +2019,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ajv": {
@@ -1978,11 +2086,19 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2017,7 +2133,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -2195,7 +2310,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2208,17 +2322,69 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2231,7 +2397,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/compare-versions": {
@@ -2320,6 +2485,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.7.0.tgz",
+      "integrity": "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ==",
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -2327,6 +2513,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -2377,6 +2573,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2385,6 +2593,26 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2427,6 +2655,12 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -2444,6 +2678,12 @@
       "dependencies": {
         "once": "^1.4.0"
       }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -2522,6 +2762,15 @@
         "@esbuild/win32-arm64": "0.25.9",
         "@esbuild/win32-ia32": "0.25.9",
         "@esbuild/win32-x64": "0.25.9"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -2782,6 +3031,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/expand-template": {
@@ -3071,6 +3343,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3106,6 +3387,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-tsconfig": {
@@ -3178,11 +3474,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3248,6 +3564,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.12.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
@@ -3292,6 +3617,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -3361,6 +3696,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3369,6 +3710,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3384,11 +3734,64 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3528,6 +3931,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3575,6 +4003,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
@@ -3583,6 +4022,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -3595,6 +4040,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -3615,6 +4066,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mimic-response": {
@@ -3650,6 +4110,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
@@ -3720,6 +4186,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
     "node_modules/node-abi": {
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
@@ -3768,6 +4240,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -3823,6 +4307,21 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3839,6 +4338,29 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {
@@ -4054,6 +4576,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4164,6 +4699,30 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4173,6 +4732,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -4181,6 +4746,28 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -4243,6 +4830,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/safari-14-idb-fix": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.6.tgz",
+      "integrity": "sha512-oTEQOdMwRX+uCtWCKT1nx2gAeSdpr8elg/2gcaKUH00SJU2xWESfkx11nmXwTRHy7xfQoj1o4TTQvdmuBosTnA==",
+      "license": "Apache-2.0"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -4425,6 +5018,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -4485,6 +5084,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4527,6 +5147,41 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4544,7 +5199,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5293,6 +5947,124 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/typescript-strict-plugin": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/typescript-strict-plugin/-/typescript-strict-plugin-2.4.4.tgz",
+      "integrity": "sha512-OXcWHQk+pW9gqEL/Mb1eTgj/Yiqk1oHBERr9v4VInPOYN++p+cXejmQK/h/VlUPGD++FXQ8pgiqVMyEtxU4T6A==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "execa": "^4.0.0",
+        "minimatch": "^9.0.3",
+        "ora": "^5.4.1",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "tsc-strict": "dist/cli/tsc-strict/index.js",
+        "update-strict-comments": "dist/cli/update-strict-comments/index.js"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-strict-plugin/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
+      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -5537,6 +6309,15 @@
         }
       }
     },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -5588,11 +6369,70 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.11.2",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/api": "^26.3.0",
+        "@actual-app/api": "^26.2.1",
         "@modelcontextprotocol/sdk": "1.27.1",
         "dotenv": "17.3.1",
         "express": "5.2.1",
@@ -38,13 +38,13 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.3.0.tgz",
-      "integrity": "sha512-03OG+udLh5GXG4I4AbfcRNhLT35vRfgHtE1JnkWGRwv6nFHY+KckPOmsDAX50fw7Q3vxPA8usHkG3JyGcRYSew==",
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.2.1.tgz",
+      "integrity": "sha512-oTgtVm0rhJBrDasCOAtgNxyFWoTyiQGGeaDYNIAgTq9uHJtUp7z7knA24ktFrMxEf3Jc92M0U393qnbrYTrv8g==",
       "license": "MIT",
       "dependencies": {
         "@actual-app/crdt": "^2.1.0",
-        "better-sqlite3": "^12.6.2",
+        "better-sqlite3": "^12.5.0",
         "compare-versions": "^6.1.1",
         "node-fetch": "^3.3.2",
         "uuid": "^13.0.0"
@@ -2041,9 +2041,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3721,9 +3721,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -4068,9 +4068,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@actual-app/api": "^26.2.1",
+    "@actual-app/api": "^26.4.0",
     "@modelcontextprotocol/sdk": "1.27.1",
     "dotenv": "17.3.1",
     "express": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@actual-app/api": "^26.3.0",
+    "@actual-app/api": "^26.2.1",
     "@modelcontextprotocol/sdk": "1.27.1",
     "dotenv": "17.3.1",
     "express": "5.2.1",

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -211,7 +211,7 @@ export async function updateCategory(id: string, args: Record<string, unknown>):
 /**
  * Delete a category (ensures API is initialized)
  */
-export async function deleteCategory(id: string): Promise<void> {
+export async function deleteCategory(id: string): Promise<unknown> {
   await initActualApi();
   return api.deleteCategory(id);
 }
@@ -290,4 +290,71 @@ export async function runBankSync(accountId?: string): Promise<void> {
   await initActualApi();
   // API expects { accountId } object or undefined for all accounts
   return api.runBankSync(accountId ? { accountId } : undefined);
+}
+
+// ----------------------------
+// BUDGETS
+// ----------------------------
+
+/**
+ * Get all budget months (ensures API is initialized)
+ */
+export async function getBudgetMonths(): Promise<string[]> {
+  await initActualApi();
+  return api.getBudgetMonths();
+}
+
+/**
+ * Get budget data for a specific month (ensures API is initialized)
+ *
+ * @param month - Month in YYYY-MM format
+ */
+export async function getBudgetMonth(month: string): Promise<unknown> {
+  await initActualApi();
+  return api.getBudgetMonth(month);
+}
+
+/**
+ * Set the budgeted amount for a category in a given month (ensures API is initialized)
+ *
+ * @param month - Month in YYYY-MM format
+ * @param categoryId - ID of the category
+ * @param value - Amount in integer cents (e.g. 12030 = $120.30)
+ */
+export async function setBudgetAmount(month: string, categoryId: string, value: number): Promise<void> {
+  await initActualApi();
+  return api.setBudgetAmount(month, categoryId, value);
+}
+
+/**
+ * Enable or disable carryover for a category in a given month (ensures API is initialized)
+ *
+ * @param month - Month in YYYY-MM format
+ * @param categoryId - ID of the category
+ * @param flag - true to enable carryover, false to disable
+ */
+export async function setBudgetCarryover(month: string, categoryId: string, flag: boolean): Promise<void> {
+  await initActualApi();
+  return api.setBudgetCarryover(month, categoryId, flag);
+}
+
+/**
+ * Hold budget funds for the next month (ensures API is initialized)
+ *
+ * @param month - Month in YYYY-MM format
+ * @param value - Amount in integer cents to hold
+ */
+export async function holdBudgetForNextMonth(month: string, value: number): Promise<boolean> {
+  await initActualApi();
+  return api.holdBudgetForNextMonth(month, value);
+}
+
+/**
+ * Reset any held budget amounts for a month (ensures API is initialized)
+ *
+ * @param month - Month in YYYY-MM format
+ */
+export async function resetBudgetHold(month: string): Promise<void> {
+  await initActualApi();
+  return api.resetBudgetHold(month);
 }

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -8,9 +8,9 @@ import {
   APICategoryEntity,
   APICategoryGroupEntity,
   APIPayeeEntity,
-} from '@actual-app/api/@types/loot-core/src/server/api-models.js';
-import { RuleEntity, TransactionEntity } from '@actual-app/api/@types/loot-core/src/types/models/index.js';
-import { ImportTransactionEntity } from '@actual-app/api/@types/loot-core/src/types/models/import-transaction.js';
+} from '@actual-app/core/server/api-models';
+import { RuleEntity, TransactionEntity } from '@actual-app/core/types/models';
+import { ImportTransactionEntity } from '@actual-app/core/types/models';
 
 const DEFAULT_DATA_DIR: string = path.resolve(os.homedir() || '.', '.actual');
 

--- a/src/core/data/fetch-rules.ts
+++ b/src/core/data/fetch-rules.ts
@@ -1,4 +1,4 @@
-import { RuleEntity } from '@actual-app/api/@types/loot-core/src/types/models/rule.js';
+import { RuleEntity } from '@actual-app/core/types/models';
 import { getRules } from '../../actual-api.js';
 
 export async function fetchAllRules(): Promise<RuleEntity[]> {

--- a/src/core/data/fetch-transactions.ts
+++ b/src/core/data/fetch-transactions.ts
@@ -3,7 +3,7 @@ import { fetchAllPayees } from './fetch-payees.js';
 import { fetchAllCategories } from './fetch-categories.js';
 import { GroupAggregator } from '../aggregation/group-by.js';
 import type { Account, Transaction, Payee, Category } from '../types/domain.js';
-import { TransactionEntity } from '@actual-app/api/@types/loot-core/src/types/models/transaction.js';
+import { TransactionEntity } from '@actual-app/core/types/models';
 
 const groupAggregator = new GroupAggregator();
 

--- a/src/core/data/fetch-transactions.ts
+++ b/src/core/data/fetch-transactions.ts
@@ -80,7 +80,7 @@ export async function fetchAllOnBudgetTransactions(
   start: string,
   end: string
 ): Promise<Transaction[]> {
-  let transactions: Transaction[] = [];
+  let transactions: TransactionEntity[] = [];
   const onBudgetAccounts = accounts.filter((a) => !a.offbudget && !a.closed);
   for (const account of onBudgetAccounts) {
     const tx = await getTransactions(account.id, start, end);
@@ -90,7 +90,7 @@ export async function fetchAllOnBudgetTransactions(
 }
 
 export async function fetchAllTransactions(accounts: Account[], start: string, end: string): Promise<Transaction[]> {
-  let transactions: Transaction[] = [];
+  let transactions: TransactionEntity[] = [];
   for (const account of accounts) {
     const tx = await getTransactions(account.id, start, end);
     transactions = [...transactions, ...tx];

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,13 @@ import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 // Reason: dotenv@17 (dotenvx) prints to stdout by default, which breaks MCP stdio JSON parsing
 dotenv.config({ path: '.env', quiet: true } as Parameters<typeof dotenv.config>[0]);
 
+// Reason: @actual-app/api fires background async tasks (e.g. updateVersion) that can reject
+// without being caught. Node ≥15 crashes on unhandled rejections by default, which kills the
+// MCP server process. We catch them here so the server stays alive and logs the issue instead.
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled promise rejection (non-fatal):', reason);
+});
+
 // Argument parsing
 const {
   values: {

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -29,8 +29,10 @@ export const setupResources = (server: Server): void => {
         })),
       };
     } catch (error) {
+      // Reason: re-throwing a non-Error APIError object causes an unhandled rejection crash in Node ≥15.
+      // Return an empty list so the MCP server stays alive when the budget isn't loaded yet.
       console.error('Error listing resources:', error);
-      throw error;
+      return { resources: [] };
     } finally {
       await shutdownActualApi();
     }

--- a/src/stubs/actual-core.d.ts
+++ b/src/stubs/actual-core.d.ts
@@ -1,0 +1,169 @@
+/**
+ * Stub type declarations for @actual-app/core.
+ *
+ * Reason: @actual-app/api >=26.4.0 imports types directly from @actual-app/core source
+ * TypeScript (.ts) files instead of compiled declaration files. Our strict tsconfig cannot
+ * compile those files. This stub covers every subpath import that @actual-app/api exposes so
+ * TypeScript resolves to this file (via tsconfig `paths`) rather than the raw source.
+ *
+ * All exports are derived from the @actual-app/core source at version 26.4.0.
+ */
+
+// ---------------------------------------------------------------------------
+// @actual-app/core/server/api-models
+// ---------------------------------------------------------------------------
+
+export type APIAccountEntity = {
+  id: string;
+  name: string;
+  offbudget?: boolean;
+  closed?: boolean;
+  balance_current?: number | null;
+  type?: string;
+  balance?: number;
+};
+
+export type APICategoryEntity = {
+  id: string;
+  name: string;
+  is_income?: boolean;
+  hidden?: boolean;
+  group_id: string;
+};
+
+export type APICategoryGroupEntity = {
+  id: string;
+  name: string;
+  is_income?: boolean;
+  hidden?: boolean;
+  categories?: APICategoryEntity[];
+};
+
+export type APIPayeeEntity = {
+  id: string;
+  name: string;
+  transfer_acct?: string;
+};
+
+export type APIFileEntity = {
+  id?: string;
+  cloudFileId: string;
+  groupId?: string;
+  name: string;
+  state?: 'remote';
+  hasKey?: boolean;
+};
+
+export type APIScheduleEntity = {
+  id: string;
+  name?: string | null;
+  posts_transaction?: boolean;
+  rule?: unknown;
+  next_date?: string | null;
+};
+
+export type APITagEntity = {
+  id: string;
+  tag: string;
+  color?: string | null;
+  description?: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// @actual-app/core/types/models
+// ---------------------------------------------------------------------------
+
+export type TransactionEntity = {
+  id: string;
+  is_parent?: boolean;
+  is_child?: boolean;
+  parent_id?: string;
+  account: string;
+  category?: string;
+  amount: number;
+  payee?: string | null;
+  notes?: string;
+  date: string;
+  imported_id?: string;
+  imported_payee?: string;
+  starting_balance_flag?: boolean;
+  transfer_id?: string;
+  sort_order?: number;
+  cleared?: boolean;
+  reconciled?: boolean;
+  tombstone?: boolean;
+  forceUpcoming?: boolean;
+  schedule?: string;
+  subtransactions?: TransactionEntity[];
+  _unmatched?: boolean;
+  _deleted?: boolean;
+  error?: { type: 'SplitTransactionError'; version: 1; difference: number } | null;
+  raw_synced_data?: string;
+  payee_name?: string;
+  category_name?: string;
+};
+
+export type RuleEntity = {
+  id: string;
+  stage: string | null;
+  conditionsOp: 'and' | 'or';
+  conditions: unknown[];
+  actions: unknown[];
+  tombstone?: boolean;
+};
+
+export type ImportTransactionEntity = {
+  account: string;
+  date: string;
+  amount?: number;
+  payee?: string | null;
+  payee_name?: string;
+  imported_id?: string;
+  imported_payee?: string;
+  category?: string;
+  notes?: string;
+  cleared?: boolean;
+  transfer_id?: string;
+  // Reason: subtransactions in import mode inherit account/date from parent, so fields are partial
+  subtransactions?: Partial<ImportTransactionEntity>[];
+};
+
+// ---------------------------------------------------------------------------
+// @actual-app/core/types/api-handlers
+// ---------------------------------------------------------------------------
+
+export type ImportTransactionsOpts = {
+  defaultCleared?: boolean;
+  dryRun?: boolean;
+  reimportDeleted?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// @actual-app/core/server/main
+// ---------------------------------------------------------------------------
+
+export type InitConfig = { dataDir: string; serverURL: string; password: string } | { dataDir: string };
+
+export declare const lib: unknown;
+
+// ---------------------------------------------------------------------------
+// @actual-app/core/shared/query
+// ---------------------------------------------------------------------------
+
+export declare class Query {
+  constructor(state: unknown);
+  filter(conditions: unknown): Query;
+  select(fields?: unknown): Query;
+  calculate(expr: unknown): Query;
+  groupBy(fields: unknown): Query;
+  orderBy(fields: unknown): Query;
+  limit(n: number): Query;
+  offset(n: number): Query;
+  raw(): unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Catch-all: any other @actual-app/core/* subpath resolves here too.
+// Exporting everything as unknown prevents implicit-any errors in strict mode.
+// ---------------------------------------------------------------------------
+export declare const _catchAll: unknown;

--- a/src/tools/budgets/get-budget-month/index.test.ts
+++ b/src/tools/budgets/get-budget-month/index.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  getBudgetMonth: vi.fn(),
+}));
+
+import { getBudgetMonth } from '../../../actual-api.js';
+
+const mockBudgetMonth = {
+  month: '2025-01',
+  incomeAvailable: 500000,
+  lastMonthOverspent: 0,
+  forNextMonth: 0,
+  totalBudgeted: -450000,
+  toBudget: 50000,
+  categoryGroups: [
+    {
+      id: 'group-1',
+      name: 'Essentials',
+      budgeted: 200000,
+      spent: -150000,
+      balance: 50000,
+      categories: [
+        { id: 'cat-1', name: 'Groceries', budgeted: 200000, spent: -150000, balance: 50000, carryover: false },
+      ],
+    },
+  ],
+};
+
+describe('get-budget-month tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('get-budget-month');
+      expect(schema.description).toContain('budget data');
+    });
+
+    it('should have inputSchema with required month field', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should return budget data for given month', async () => {
+      vi.mocked(getBudgetMonth).mockResolvedValue(mockBudgetMonth);
+
+      const result = await handler({ month: '2025-01' });
+
+      expect(getBudgetMonth).toHaveBeenCalledWith('2025-01');
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Groceries');
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should return error when month is missing', async () => {
+      const result = await handler({});
+
+      expect(result.isError).toBe(true);
+      expect(getBudgetMonth).not.toHaveBeenCalled();
+    });
+
+    it('should return error when month is not a string', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await handler({ month: 202501 } as any);
+
+      expect(result.isError).toBe(true);
+      expect(getBudgetMonth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(getBudgetMonth).mockRejectedValue(new Error('Month not found'));
+
+      const result = await handler({ month: '2025-01' });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Month not found');
+    });
+  });
+});

--- a/src/tools/budgets/get-budget-month/index.ts
+++ b/src/tools/budgets/get-budget-month/index.ts
@@ -1,0 +1,34 @@
+// ----------------------------
+// GET BUDGET MONTH TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { getBudgetMonth } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const GetBudgetMonthArgsSchema = z.object({
+  month: z.string().describe('Month in YYYY-MM format (e.g. "2025-01")'),
+});
+
+export const schema = {
+  name: 'get-budget-month',
+  description:
+    'Retrieve budget data for a specific month, including budgeted amounts, spending, and balances per category.',
+  inputSchema: toJSONSchema(GetBudgetMonthArgsSchema) as ToolInput,
+};
+
+export async function handler(
+  args: Record<string, unknown>
+): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const parsed = GetBudgetMonthArgsSchema.safeParse(args);
+    if (!parsed.success) {
+      return errorFromCatch(`Invalid arguments: ${parsed.error.message}`);
+    }
+    const data = await getBudgetMonth(parsed.data.month);
+    return successWithJson(data);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/budgets/get-budget-months/index.test.ts
+++ b/src/tools/budgets/get-budget-months/index.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  getBudgetMonths: vi.fn(),
+}));
+
+import { getBudgetMonths } from '../../../actual-api.js';
+
+describe('get-budget-months tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('get-budget-months');
+      expect(schema.description).toContain('budget months');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should return list of budget months', async () => {
+      const months = ['2025-01', '2025-02', '2025-03'];
+      vi.mocked(getBudgetMonths).mockResolvedValue(months);
+
+      const result = await handler();
+
+      expect(getBudgetMonths).toHaveBeenCalledOnce();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('2025-01');
+    });
+
+    it('should return empty array when no months exist', async () => {
+      vi.mocked(getBudgetMonths).mockResolvedValue([]);
+
+      const result = await handler();
+
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('[]');
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(getBudgetMonths).mockRejectedValue(new Error('Connection failed'));
+
+      const result = await handler();
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Connection failed');
+    });
+  });
+});

--- a/src/tools/budgets/get-budget-months/index.ts
+++ b/src/tools/budgets/get-budget-months/index.ts
@@ -1,0 +1,25 @@
+// ----------------------------
+// GET BUDGET MONTHS TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { getBudgetMonths } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const GetBudgetMonthsArgsSchema = z.object({});
+
+export const schema = {
+  name: 'get-budget-months',
+  description: 'Retrieve a list of all available budget months in YYYY-MM format.',
+  inputSchema: toJSONSchema(GetBudgetMonthsArgsSchema) as ToolInput,
+};
+
+export async function handler(): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const months = await getBudgetMonths();
+    return successWithJson(months);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/budgets/hold-budget-for-next-month/index.test.ts
+++ b/src/tools/budgets/hold-budget-for-next-month/index.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  holdBudgetForNextMonth: vi.fn(),
+}));
+
+import { holdBudgetForNextMonth } from '../../../actual-api.js';
+
+describe('hold-budget-for-next-month tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('hold-budget-for-next-month');
+      expect(schema.description).toContain('budget funds');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should hold budget and return success message', async () => {
+      vi.mocked(holdBudgetForNextMonth).mockResolvedValue(true);
+
+      const result = await handler({ month: '2025-01', value: 10000 });
+
+      expect(holdBudgetForNextMonth).toHaveBeenCalledWith('2025-01', 10000);
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('10000');
+    });
+
+    it('should handle holding zero cents (no-op hold)', async () => {
+      vi.mocked(holdBudgetForNextMonth).mockResolvedValue(true);
+
+      const result = await handler({ month: '2025-03', value: 0 });
+
+      expect(holdBudgetForNextMonth).toHaveBeenCalledWith('2025-03', 0);
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should return error when value is missing', async () => {
+      const result = await handler({ month: '2025-01' });
+
+      expect(result.isError).toBe(true);
+      expect(holdBudgetForNextMonth).not.toHaveBeenCalled();
+    });
+
+    it('should return error when value is a decimal', async () => {
+      const result = await handler({ month: '2025-01', value: 99.99 });
+
+      expect(result.isError).toBe(true);
+      expect(holdBudgetForNextMonth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(holdBudgetForNextMonth).mockRejectedValue(new Error('Insufficient funds'));
+
+      const result = await handler({ month: '2025-01', value: 99999999 });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Insufficient funds');
+    });
+  });
+});

--- a/src/tools/budgets/hold-budget-for-next-month/index.ts
+++ b/src/tools/budgets/hold-budget-for-next-month/index.ts
@@ -1,0 +1,36 @@
+// ----------------------------
+// HOLD BUDGET FOR NEXT MONTH TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { holdBudgetForNextMonth } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const HoldBudgetForNextMonthArgsSchema = z.object({
+  month: z.string().describe('Month in YYYY-MM format (e.g. "2025-01")'),
+  value: z.number().int().describe('Amount in integer cents to hold for the next month (e.g. 5000 = $50.00)'),
+});
+
+export const schema = {
+  name: 'hold-budget-for-next-month',
+  description:
+    'Reserve budget funds from the current month to be used in the following month. Value must be in integer cents.',
+  inputSchema: toJSONSchema(HoldBudgetForNextMonthArgsSchema) as ToolInput,
+};
+
+export async function handler(
+  args: Record<string, unknown>
+): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const parsed = HoldBudgetForNextMonthArgsSchema.safeParse(args);
+    if (!parsed.success) {
+      return errorFromCatch(`Invalid arguments: ${parsed.error.message}`);
+    }
+    const { month, value } = parsed.data;
+    await holdBudgetForNextMonth(month, value);
+    return successWithJson(`Successfully held ${value} cents for next month from ${month}`);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/budgets/reset-budget-hold/index.test.ts
+++ b/src/tools/budgets/reset-budget-hold/index.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  resetBudgetHold: vi.fn(),
+}));
+
+import { resetBudgetHold } from '../../../actual-api.js';
+
+describe('reset-budget-hold tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('reset-budget-hold');
+      expect(schema.description).toContain('held budget');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should reset budget hold and return success message', async () => {
+      vi.mocked(resetBudgetHold).mockResolvedValue(undefined);
+
+      const result = await handler({ month: '2025-01' });
+
+      expect(resetBudgetHold).toHaveBeenCalledWith('2025-01');
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('2025-01');
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should return error when month is missing', async () => {
+      const result = await handler({});
+
+      expect(result.isError).toBe(true);
+      expect(resetBudgetHold).not.toHaveBeenCalled();
+    });
+
+    it('should return error when month is not a string', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await handler({ month: 202501 } as any);
+
+      expect(result.isError).toBe(true);
+      expect(resetBudgetHold).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(resetBudgetHold).mockRejectedValue(new Error('Reset failed'));
+
+      const result = await handler({ month: '2025-01' });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Reset failed');
+    });
+  });
+});

--- a/src/tools/budgets/reset-budget-hold/index.ts
+++ b/src/tools/budgets/reset-budget-hold/index.ts
@@ -1,0 +1,33 @@
+// ----------------------------
+// RESET BUDGET HOLD TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { resetBudgetHold } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const ResetBudgetHoldArgsSchema = z.object({
+  month: z.string().describe('Month in YYYY-MM format (e.g. "2025-01")'),
+});
+
+export const schema = {
+  name: 'reset-budget-hold',
+  description: 'Clear any held budget amounts for a specified month, releasing them back to the available balance.',
+  inputSchema: toJSONSchema(ResetBudgetHoldArgsSchema) as ToolInput,
+};
+
+export async function handler(
+  args: Record<string, unknown>
+): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const parsed = ResetBudgetHoldArgsSchema.safeParse(args);
+    if (!parsed.success) {
+      return errorFromCatch(`Invalid arguments: ${parsed.error.message}`);
+    }
+    await resetBudgetHold(parsed.data.month);
+    return successWithJson(`Successfully reset budget hold for ${parsed.data.month}`);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/budgets/set-budget-amount/index.test.ts
+++ b/src/tools/budgets/set-budget-amount/index.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  setBudgetAmount: vi.fn(),
+}));
+
+import { setBudgetAmount } from '../../../actual-api.js';
+
+describe('set-budget-amount tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('set-budget-amount');
+      expect(schema.description).toContain('budgeted amount');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should set budget amount and return success message', async () => {
+      vi.mocked(setBudgetAmount).mockResolvedValue(undefined);
+
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123', value: 50000 });
+
+      expect(setBudgetAmount).toHaveBeenCalledWith('2025-01', 'cat-123', 50000);
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('cat-123');
+    });
+
+    it('should handle zero value (clearing a budget)', async () => {
+      vi.mocked(setBudgetAmount).mockResolvedValue(undefined);
+
+      const result = await handler({ month: '2025-06', categoryId: 'cat-456', value: 0 });
+
+      expect(setBudgetAmount).toHaveBeenCalledWith('2025-06', 'cat-456', 0);
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should return error when month is missing', async () => {
+      const result = await handler({ categoryId: 'cat-123', value: 5000 });
+
+      expect(result.isError).toBe(true);
+      expect(setBudgetAmount).not.toHaveBeenCalled();
+    });
+
+    it('should return error when value is not an integer', async () => {
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123', value: 50.5 });
+
+      expect(result.isError).toBe(true);
+      expect(setBudgetAmount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(setBudgetAmount).mockRejectedValue(new Error('Category not found'));
+
+      const result = await handler({ month: '2025-01', categoryId: 'cat-999', value: 10000 });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Category not found');
+    });
+  });
+});

--- a/src/tools/budgets/set-budget-amount/index.ts
+++ b/src/tools/budgets/set-budget-amount/index.ts
@@ -1,0 +1,37 @@
+// ----------------------------
+// SET BUDGET AMOUNT TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { setBudgetAmount } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const SetBudgetAmountArgsSchema = z.object({
+  month: z.string().describe('Month in YYYY-MM format (e.g. "2025-01")'),
+  categoryId: z.string().describe('ID of the category to budget'),
+  value: z.number().int().describe('Budgeted amount in integer cents (e.g. 12030 = $120.30)'),
+});
+
+export const schema = {
+  name: 'set-budget-amount',
+  description:
+    'Set the budgeted amount for a category in a given month. Value must be in integer cents (e.g. 12030 = $120.30).',
+  inputSchema: toJSONSchema(SetBudgetAmountArgsSchema) as ToolInput,
+};
+
+export async function handler(
+  args: Record<string, unknown>
+): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const parsed = SetBudgetAmountArgsSchema.safeParse(args);
+    if (!parsed.success) {
+      return errorFromCatch(`Invalid arguments: ${parsed.error.message}`);
+    }
+    const { month, categoryId, value } = parsed.data;
+    await setBudgetAmount(month, categoryId, value);
+    return successWithJson(`Successfully set budget amount for category ${categoryId} in ${month}`);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/budgets/set-budget-carryover/index.test.ts
+++ b/src/tools/budgets/set-budget-carryover/index.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  setBudgetCarryover: vi.fn(),
+}));
+
+import { setBudgetCarryover } from '../../../actual-api.js';
+
+describe('set-budget-carryover tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('set-budget-carryover');
+      expect(schema.description).toContain('carryover');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should enable carryover and return success message', async () => {
+      vi.mocked(setBudgetCarryover).mockResolvedValue(undefined);
+
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123', flag: true });
+
+      expect(setBudgetCarryover).toHaveBeenCalledWith('2025-01', 'cat-123', true);
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('enabled');
+    });
+
+    it('should disable carryover and indicate so in the message', async () => {
+      vi.mocked(setBudgetCarryover).mockResolvedValue(undefined);
+
+      const result = await handler({ month: '2025-02', categoryId: 'cat-456', flag: false });
+
+      expect(setBudgetCarryover).toHaveBeenCalledWith('2025-02', 'cat-456', false);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('disabled');
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should return error when flag is missing', async () => {
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123' });
+
+      expect(result.isError).toBe(true);
+      expect(setBudgetCarryover).not.toHaveBeenCalled();
+    });
+
+    it('should return error when flag is not a boolean', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123', flag: 'yes' } as any);
+
+      expect(result.isError).toBe(true);
+      expect(setBudgetCarryover).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(setBudgetCarryover).mockRejectedValue(new Error('Database error'));
+
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123', flag: true });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Database error');
+    });
+  });
+});

--- a/src/tools/budgets/set-budget-carryover/index.ts
+++ b/src/tools/budgets/set-budget-carryover/index.ts
@@ -1,0 +1,38 @@
+// ----------------------------
+// SET BUDGET CARRYOVER TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { setBudgetCarryover } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const SetBudgetCarryoverArgsSchema = z.object({
+  month: z.string().describe('Month in YYYY-MM format (e.g. "2025-01")'),
+  categoryId: z.string().describe('ID of the category'),
+  flag: z.boolean().describe('true to enable carryover of unspent funds, false to disable'),
+});
+
+export const schema = {
+  name: 'set-budget-carryover',
+  description: 'Enable or disable carryover of unspent funds for a category into the next month.',
+  inputSchema: toJSONSchema(SetBudgetCarryoverArgsSchema) as ToolInput,
+};
+
+export async function handler(
+  args: Record<string, unknown>
+): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const parsed = SetBudgetCarryoverArgsSchema.safeParse(args);
+    if (!parsed.success) {
+      return errorFromCatch(`Invalid arguments: ${parsed.error.message}`);
+    }
+    const { month, categoryId, flag } = parsed.data;
+    await setBudgetCarryover(month, categoryId, flag);
+    return successWithJson(
+      `Successfully ${flag ? 'enabled' : 'disabled'} carryover for category ${categoryId} in ${month}`
+    );
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -32,6 +32,12 @@ import * as updateTransaction from './update-transaction/index.js';
 import * as createTransaction from './create-transaction/index.js';
 import * as importTransactions from './import-transactions/index.js';
 import * as runBankSync from './run-bank-sync/index.js';
+import * as getBudgetMonths from './budgets/get-budget-months/index.js';
+import * as getBudgetMonth from './budgets/get-budget-month/index.js';
+import * as setBudgetAmount from './budgets/set-budget-amount/index.js';
+import * as setBudgetCarryover from './budgets/set-budget-carryover/index.js';
+import * as holdBudgetForNextMonth from './budgets/hold-budget-for-next-month/index.js';
+import * as resetBudgetHold from './budgets/reset-budget-hold/index.js';
 
 const readTools = [
   getTransactions,
@@ -42,6 +48,8 @@ const readTools = [
   getGroupedCategories,
   getPayees,
   getRules,
+  getBudgetMonths,
+  getBudgetMonth,
 ];
 
 const writeTools = [
@@ -62,6 +70,10 @@ const writeTools = [
   createTransaction,
   importTransactions,
   runBankSync,
+  setBudgetAmount,
+  setBudgetCarryover,
+  holdBudgetForNextMonth,
+  resetBudgetHold,
 ];
 
 export const setupTools = (server: Server, enableWrite: boolean): void => {

--- a/src/tools/rules/create-rule/index.ts
+++ b/src/tools/rules/create-rule/index.ts
@@ -5,7 +5,7 @@
 import { successWithJson, errorFromCatch } from '../../../utils/response.js';
 import { createRule } from '../../../actual-api.js';
 import { RuleInputSchema } from '../input-schema.js';
-import { RuleEntity } from '@actual-app/api/@types/loot-core/src/types/models/rule.js';
+import { RuleEntity } from '@actual-app/core/types/models';
 
 export const schema = {
   name: 'create-rule',

--- a/src/tools/rules/get-rules/index.ts
+++ b/src/tools/rules/get-rules/index.ts
@@ -5,7 +5,7 @@
 import { successWithJson, errorFromCatch } from '../../../utils/response.js';
 // import type { Rule } from '../../../types.js';
 import { fetchAllRules } from '../../../core/data/fetch-rules.js';
-import { RuleEntity } from '@actual-app/api/@types/loot-core/src/types/models/rule.js';
+import { RuleEntity } from '@actual-app/core/types/models';
 
 export const schema = {
   name: 'get-rules',

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -78,7 +78,12 @@ export function errorFromCatch(err: unknown): CallToolResult {
   let message: string;
   if (err instanceof Error) {
     message = err.message;
-  } else if (typeof err === 'object' && err !== null && 'message' in err && typeof (err as Record<string, unknown>).message === 'string') {
+  } else if (
+    typeof err === 'object' &&
+    err !== null &&
+    'message' in err &&
+    typeof (err as Record<string, unknown>).message === 'string'
+  ) {
     // Reason: @actual-app/api throws structured objects like { type: 'APIError', message: '...' }
     // rather than Error instances. Extract the message field so errors are human-readable.
     message = (err as Record<string, unknown>).message as string;

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -75,7 +75,16 @@ export function error(message: string): CallToolResult {
  * @returns An error response object
  */
 export function errorFromCatch(err: unknown): CallToolResult {
-  const message = err instanceof Error ? err.message : String(err);
+  let message: string;
+  if (err instanceof Error) {
+    message = err.message;
+  } else if (typeof err === 'object' && err !== null && 'message' in err && typeof (err as Record<string, unknown>).message === 'string') {
+    // Reason: @actual-app/api throws structured objects like { type: 'APIError', message: '...' }
+    // rather than Error instances. Extract the message field so errors are human-readable.
+    message = (err as Record<string, unknown>).message as string;
+  } else {
+    message = String(err);
+  }
   return error(message);
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,10 @@
     "declarationDir": "./build",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["vitest/globals", "node"]
+    "types": ["vitest/globals", "node"],
+    "paths": {
+      "@actual-app/core/*": ["./src/stubs/actual-core.d.ts"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "build"]


### PR DESCRIPTION
## Summary

- Exposes all 6 Actual Budget API budget functions as MCP tools, completing the budgeting workflow for AI assistants
- Fixes three pre-existing MCP server stability bugs discovered during integration testing
- Bumps `@actual-app/api` from 26.2.1 → 26.4.0 to support the latest Actual Budget server

## New tools

| Tool | Type | Description |
|---|---|---|
| `get-budget-months` | READ | Returns all months with budget data (YYYY-MM strings) |
| `get-budget-month` | READ | Returns full budget detail for a given month |
| `set-budget-amount` | WRITE | Sets the budgeted amount (in cents) for a category/month |
| `set-budget-carryover` | WRITE | Enables/disables carryover for a category/month |
| `hold-budget-for-next-month` | WRITE | Holds funds to carry forward to the next month |
| `reset-budget-hold` | WRITE | Resets any held budget amounts for a month |

## Stability fixes (pre-existing bugs)

- **`[Breadcrumb...]` stdout corruption**: Sentry in `@actual-app/api` wrote to stdout on crash, corrupting the MCP stdio JSON protocol. Fixed by preventing the crash (see below) and adding an `unhandledRejection` process guard in `index.ts`.
- **`UnhandledPromiseRejection` crash**: `resources.ts` re-threw structured API error objects that Node.js v25 treats as fatal. Changed to return `{ resources: [] }` gracefully.
- **`[object Object]` error messages**: `errorFromCatch` in `response.ts` serialized structured `{ type, message }` API errors as `[object Object]`. Fixed to extract the `.message` field.

## 26.4.0 upgrade notes

`@actual-app/core` in 26.4.0 ships raw TypeScript source files instead of compiled `.d.ts` declarations. Since `skipLibCheck` only covers `.d.ts` files, the strict tsconfig failed to compile those files. Solution:

- Added `src/stubs/actual-core.d.ts`: hand-written type stubs covering every `@actual-app/core/*` subpath the codebase imports
- Added `tsconfig.json` `paths` entry to redirect all `@actual-app/core/*` imports to the stub
- Updated all import paths from the old `@actual-app/api/@types/loot-core/src/...` paths to the new `@actual-app/core/...` paths

## Test plan

- [x] `npm run type-check` — no TypeScript errors
- [x] `npm run lint` — no lint errors
- [x] `npm run test` — all new tests pass (181 tests pass; 2 pre-existing failures in `transaction-aggregator.test.ts` unrelated to this PR)
- [x] `npm run build` — build succeeds
- [x] Live MCP test: `get-budget-months`, `get-budget-month`, `set-budget-amount` all verified working against Actual Budget v26.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)