### PR TITLE
feat(get-transactions): expose transfer_id in markdown output

### DIFF
--- a/src/tools/get-transactions/report-generator.test.ts
+++ b/src/tools/get-transactions/report-generator.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { GetTransactionsReportGenerator } from './report-generator.js';
+
+describe('GetTransactionsReportGenerator', () => {
+  const generator = new GetTransactionsReportGenerator();
+
+  const transferRow = {
+    id: 'tx-1',
+    date: '2024-05-01',
+    payee: 'Savings',
+    category: '(Uncategorized)',
+    amount: '$50.00',
+    notes: '',
+    cleared: true,
+    transferId: 'tx-2',
+  };
+
+  const regularRow = {
+    id: 'tx-3',
+    date: '2024-05-02',
+    payee: 'Coffee Shop',
+    category: 'Dining',
+    amount: '-$12.34',
+    notes: 'morning',
+    cleared: false,
+    transferId: '',
+  };
+
+  it('renders the Transfer column in the header', () => {
+    const md = generator.generate([transferRow], 'Date range: 2024-05-01 to 2024-05-31', 1, 1);
+
+    expect(md).toContain('| ID | Date | Payee | Category | Amount | Cleared | Notes | Transfer |');
+    expect(md).toContain('| ---- | ----- | -------- | ------ | ----- | ------- | ----- | -------- |');
+  });
+
+  it('renders transferId in the Transfer cell for transfer rows', () => {
+    const md = generator.generate([transferRow], '', 1, 1);
+
+    expect(md).toContain('| tx-1 | 2024-05-01 | Savings | (Uncategorized) | $50.00 | true |  | tx-2 |');
+  });
+
+  it('leaves the Transfer cell empty for non-transfer rows', () => {
+    const md = generator.generate([regularRow], '', 1, 1);
+
+    expect(md).toContain('| tx-3 | 2024-05-02 | Coffee Shop | Dining | -$12.34 | false | morning |  |');
+  });
+
+  it('preserves the leading columns so name-anchored parsers do not break', () => {
+    const md = generator.generate([regularRow], '', 1, 1);
+    const headerLine = md.split('\n').find((line) => line.startsWith('| ID |'));
+
+    expect(headerLine).toBeDefined();
+    const headers = headerLine!
+      .split('|')
+      .map((c) => c.trim())
+      .filter(Boolean);
+    expect(headers.slice(0, 7)).toEqual(['ID', 'Date', 'Payee', 'Category', 'Amount', 'Cleared', 'Notes']);
+    expect(headers[7]).toBe('Transfer');
+  });
+});

--- a/src/tools/get-transactions/report-generator.ts
+++ b/src/tools/get-transactions/report-generator.ts
@@ -10,15 +10,19 @@ export class GetTransactionsReportGenerator {
       amount: string;
       notes: string;
       cleared: boolean;
+      transferId: string;
     }>,
     filterDescription: string,
     filteredCount: number,
     totalCount: number
   ): string {
     const header =
-      '| ID | Date | Payee | Category | Amount | Cleared | Notes |\n| ---- | ----- | -------- | ------ | ----- | ------- | ----- |\n';
+      '| ID | Date | Payee | Category | Amount | Cleared | Notes | Transfer |\n| ---- | ----- | -------- | ------ | ----- | ------- | ----- | -------- |\n';
     const rows = mappedTransactions
-      .map((t) => `| ${t.id} | ${t.date} | ${t.payee} | ${t.category} | ${t.amount} | ${t.cleared} | ${t.notes} |`)
+      .map(
+        (t) =>
+          `| ${t.id} | ${t.date} | ${t.payee} | ${t.category} | ${t.amount} | ${t.cleared} | ${t.notes} | ${t.transferId} |`
+      )
       .join('\n');
     return `# Filtered Transactions\n\n${filterDescription}\nMatching Transactions: ${filteredCount}/${totalCount}\n\n${header}${rows}`;
   }

--- a/src/tools/get-transactions/transaction-mapper.test.ts
+++ b/src/tools/get-transactions/transaction-mapper.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { GetTransactionsMapper } from './transaction-mapper.js';
+import type { Transaction } from '../../core/types/domain.js';
+
+describe('GetTransactionsMapper', () => {
+  const mapper = new GetTransactionsMapper();
+
+  it('exposes transfer_id as transferId when set', () => {
+    const tx: Transaction = {
+      id: 'tx-1',
+      account: 'acc-1',
+      date: '2024-05-01',
+      amount: 5000,
+      payee_name: 'Savings',
+      transfer_id: 'tx-2',
+      cleared: true,
+    };
+
+    const [mapped] = mapper.map([tx]);
+
+    expect(mapped.transferId).toBe('tx-2');
+  });
+
+  it('emits empty transferId for non-transfer transactions', () => {
+    const tx: Transaction = {
+      id: 'tx-3',
+      account: 'acc-1',
+      date: '2024-05-02',
+      amount: -1234,
+      payee_name: 'Coffee Shop',
+      category_name: 'Dining',
+      cleared: false,
+    };
+
+    const [mapped] = mapper.map([tx]);
+
+    expect(mapped.transferId).toBe('');
+  });
+
+  it('falls back to placeholders for missing payee, category, and notes', () => {
+    const tx: Transaction = {
+      id: 'tx-4',
+      account: 'acc-1',
+      date: '2024-05-03',
+      amount: -50,
+    };
+
+    const [mapped] = mapper.map([tx]);
+
+    expect(mapped.payee).toBe('(No payee)');
+    expect(mapped.category).toBe('(Uncategorized)');
+    expect(mapped.notes).toBe('');
+    expect(mapped.cleared).toBe(false);
+    expect(mapped.transferId).toBe('');
+  });
+});

--- a/src/tools/get-transactions/transaction-mapper.ts
+++ b/src/tools/get-transactions/transaction-mapper.ts
@@ -11,6 +11,7 @@ export class GetTransactionsMapper {
     amount: string;
     notes: string;
     cleared: boolean;
+    transferId: string;
   }> {
     return transactions.map((t) => ({
       id: t.id,
@@ -20,6 +21,7 @@ export class GetTransactionsMapper {
       amount: formatAmount(t.amount),
       notes: t.notes || '',
       cleared: t.cleared ?? false,
+      transferId: t.transfer_id || '',
     }));
   }
 }


### PR DESCRIPTION
Closes #168.

## Summary

Add a `Transfer` column to the `get-transactions` markdown table so MCP clients can identify transfer transactions without resorting to payee-name heuristics. The Actual API already returns `transfer_id` on every transaction, the field is declared on the internal `Transaction` type (`src/core/types/domain.ts`), and `monthly-summary` already uses it internally — but the `get-transactions` mapper was dropping it before the response was built.

## Changes

- `src/tools/get-transactions/transaction-mapper.ts`: pass `transferId: t.transfer_id || ''` through to the mapped row.
- `src/tools/get-transactions/report-generator.ts`: append a `Transfer` column at the end of the header and rows. Non-transfer rows render an empty cell.

The new column is appended **at the end** so existing column positions (`ID | Date | Payee | Category | Amount | Cleared | Notes`) are preserved for parsers that anchor on header names.

### New table shape

```
| ID | Date | Payee | Category | Amount | Cleared | Notes | Transfer |
| ---- | ----- | -------- | ------ | ----- | ------- | ----- | -------- |
| tx-1 | 2024-05-01 | Savings | (Uncategorized) | $50.00 | true |  | tx-2 |
| tx-3 | 2024-05-02 | Coffee Shop | Dining | -$12.34 | false | morning |  |
```

## Tests

Added unit tests for both files (neither had tests before):

- `transaction-mapper.test.ts` — `transferId` is passed through when `transfer_id` is set, empty otherwise, plus default-fallback behavior for payee/category/notes.
- `report-generator.test.ts` — `Transfer` column appears in the header and separator, transfer rows show the id, non-transfer rows show empty, and the leading seven columns stay in place.

`npm test` → 17 files, 152 tests passing (was 15/145).
`npm run lint`, `npm run type-check`, `npm run build` all green.

## Why

Concrete motivating use case: building an MCP-driven agent skill that reports *uncategorized* transactions for a single account and excludes inter-account transfers (which Actual leaves uncategorized by design). With `transfer_id` exposed, the filter is a clean `category === '(Uncategorized)' && transferId === ''`. Without it, the client falls back to fuzzy payee-name matching against the account list, which is unreliable when transfer payees are renamed or when merchant names collide with account names.