### PR TITLE
chore(ci): restrict Claude workflows to repo owner

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,17 @@
 name: Claude Code Review
 
+# Auto-review on PR events is disabled — use `@claude` mentions (handled by claude.yml)
+# or trigger this workflow manually via the Actions tab.
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  workflow_dispatch:
+  # pull_request:
+  #   types: [opened, synchronize, ready_for_review, reopened]
+  #   # Optional: Only run on specific file changes
+  #   # paths:
+  #   #   - "src/**/*.ts"
+  #   #   - "src/**/*.tsx"
+  #   #   - "src/**/*.js"
+  #   #   - "src/**/*.jsx"
 
 jobs:
   claude-review:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   claude:
+    # Restricted to the repo owner to prevent strangers from spending the OAuth token's quota.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.author_association == 'OWNER') ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.author_association == 'OWNER') ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.review.author_association == 'OWNER') ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.author_association == 'OWNER')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Disable auto-review on `pull_request` events in `claude-code-review.yml`. Trigger swapped to `workflow_dispatch` so the workflow can still be launched manually from the Actions tab; the original triggers are preserved as comments for an easy revert.
- Gate `claude.yml` on `author_association == 'OWNER'` for every event branch (`issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues`). Only the repo owner's `@claude` mentions will spend the OAuth token's quota — drive-by mentions from random commenters are silently ignored.

## Why

This is a public repo and `secrets.CLAUDE_CODE_OAUTH_TOKEN` is billed to my Claude subscription. Without an author guard, any GitHub user can comment `@claude` on an issue/PR and consume quota.

## Test plan

- [ ] Open this PR — `claude-code-review.yml` should **not** auto-run (no PR-event trigger anymore).
- [ ] Comment `@claude ping` as the owner on any issue/PR → `claude.yml` job runs.
- [ ] Have a non-owner account comment `@claude ping` → `claude.yml` job is skipped (the `if:` evaluates false).
- [ ] Manually dispatch `Claude Code Review` from the Actions tab → it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)