### PR TITLE
fix: redirect stdout-bound console logs to stderr in stdio mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { initActualApi, shutdownActualApi } from './actual-api.js';
 import { fetchAllAccounts } from './core/data/fetch-accounts.js';
 import { createServer } from './server.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { redirectConsoleToStderr } from './utils/redirect-console.js';
 
 // Reason: dotenv@17 (dotenvx) prints to stdout by default, which breaks MCP stdio JSON parsing
 dotenv.config({ path: '.env', quiet: true } as Parameters<typeof dotenv.config>[0]);
@@ -49,6 +50,13 @@ const {
 });
 
 const resolvedPort = port ? parseInt(port, 10) : 3000;
+
+// Reason: in stdio mode stdout carries only JSON-RPC; @actual-app/api logs via
+// console.log ("[Breadcrumb]", "Loaded spreadsheet", ...) which would corrupt
+// the protocol stream, so route those to stderr before the API can log anything.
+if (!useSse && !testResources && !testCustom) {
+  redirectConsoleToStderr();
+}
 
 // Bearer authentication middleware
 const bearerAuth = (req: Request, res: Response, next: NextFunction): void => {

--- a/src/utils/redirect-console.test.ts
+++ b/src/utils/redirect-console.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { redirectConsoleToStderr } from './redirect-console.js';
+
+describe('redirectConsoleToStderr', () => {
+  let restore: (() => void) | undefined;
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('should write console.log, console.info, and console.debug to stderr', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    restore = redirectConsoleToStderr();
+
+    console.log('log message');
+    console.info('info message');
+    console.debug('debug message');
+
+    expect(stderrSpy).toHaveBeenCalledWith('log message\n');
+    expect(stderrSpy).toHaveBeenCalledWith('info message\n');
+    expect(stderrSpy).toHaveBeenCalledWith('debug message\n');
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('should format multiple arguments and objects like console.log', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    restore = redirectConsoleToStderr();
+
+    console.log('[Breadcrumb]', { message: 'loaded spreadsheet', category: 'server' });
+
+    expect(stderrSpy).toHaveBeenCalledWith("[Breadcrumb] { message: 'loaded spreadsheet', category: 'server' }\n");
+  });
+
+  it('should restore original console methods when the returned function is called', () => {
+    const originalLog = console.log;
+    const originalInfo = console.info;
+    const originalDebug = console.debug;
+
+    const restoreFn = redirectConsoleToStderr();
+    expect(console.log).not.toBe(originalLog);
+
+    restoreFn();
+
+    expect(console.log).toBe(originalLog);
+    expect(console.info).toBe(originalInfo);
+    expect(console.debug).toBe(originalDebug);
+  });
+});

--- a/src/utils/redirect-console.ts
+++ b/src/utils/redirect-console.ts
@@ -1,0 +1,41 @@
+// ----------------------------
+// CONSOLE REDIRECTION FOR STDIO MODE
+// ----------------------------
+
+import { format } from 'node:util';
+
+/**
+ * Redirect stdout-bound console methods (log, info, debug) to stderr.
+ *
+ * In MCP stdio mode, stdout is reserved exclusively for JSON-RPC messages.
+ * Dependencies such as @actual-app/api's internal logger write informational
+ * logs (e.g. "[Breadcrumb] ...", "Loaded spreadsheet ...", "Syncing since ...")
+ * via console.log/console.info, which corrupts the protocol stream and causes
+ * "Unexpected token ... is not valid JSON" errors in MCP clients.
+ *
+ * console.warn and console.error already write to stderr in Node.js, so they
+ * are left untouched.
+ *
+ * @returns A function that restores the original console methods
+ */
+export function redirectConsoleToStderr(): () => void {
+  const original = {
+    log: console.log,
+    info: console.info,
+    debug: console.debug,
+  };
+
+  const writeToStderr = (...args: unknown[]): void => {
+    process.stderr.write(format(...args) + '\n');
+  };
+
+  console.log = writeToStderr;
+  console.info = writeToStderr;
+  console.debug = writeToStderr;
+
+  return (): void => {
+    console.log = original.log;
+    console.info = original.info;
+    console.debug = original.debug;
+  };
+}


### PR DESCRIPTION
## Problem

When running the server in stdio mode (e.g. via Claude Desktop), MCP clients log repeated JSON parse errors during initialization:

```
[error] Unexpected token 'B', "[Breadcrumb] {" is not valid JSON
[error] Unexpected token 'L', "Loaded spr"... is not valid JSON
[error] Unexpected token 'S', "Syncing si"... is not valid JSON
[error] Unexpected token 'G', "Got messag"... is not valid JSON
```

`@actual-app/api`'s internal logger (loot-core's `platform/server/log`) writes informational messages — `[Breadcrumb] {...}`, `Loaded spreadsheet from cache`, `Syncing since ...`, `Got messages from server` — via `console.log`/`console.info`, which go to **stdout**. In MCP stdio mode, stdout is reserved exclusively for JSON-RPC messages, so every one of these lines corrupts the protocol stream and the client throws on `JSON.parse`.

The server's own logging already correctly uses `console.error` (stderr); the pollution comes entirely from the dependency, which offers no supported way to reroute its logger output.

## Fix

Add a small `redirectConsoleToStderr()` utility that reroutes `console.log`/`console.info`/`console.debug` to stderr (preserving `util.format` semantics), and call it in `index.ts` before the stdio server starts. `console.warn`/`console.error` already write to stderr in Node, so they're untouched.

The redirect is gated to stdio server mode only — SSE/HTTP mode and the `--test-resources`/`--test-custom` modes keep their normal stdout behavior.

## Testing

- Added unit tests (`src/utils/redirect-console.test.ts`): redirection of all three methods, `util.format` argument formatting, and restore behavior. Full suite: 155 tests pass.
- Verified end-to-end against a real Actual server: drove `build/index.js` over stdio with `initialize` → `resources/list` (which triggers full budget download/sync). Before: `[Breadcrumb]`/`Loaded spreadsheet`/`Syncing since` lines appeared on stdout. After: stdout contains only valid JSON-RPC lines, and all library logs appear on stderr where MCP hosts capture them as diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)