### PR TITLE
fix: bump @actual-app/api to ^26.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,12 +285,6 @@ npx @modelcontextprotocol/inspector node build/index.js
 - `prompts.ts` - Prompt templates for LLM interactions
 - `utils.ts` - Helper functions for date formatting and more
 
-## Fork Modifications
-
-This fork includes the following changes from the upstream [s-stefanov/actual-mcp](https://github.com/s-stefanov/actual-mcp):
-
-- **`@actual-app/api` bumped from `^26.3.0` to `^26.5.0`** — updates the Actual Budget API client to the latest version for compatibility with newer Actual server releases.
-- **Balance cutoff fix** — `getAccountBalance` calls now pass a far-future cutoff date (`2099-01-01`) so that future-dated pending transactions are included in balance calculations. Without this fix, banks that pre-date pending transactions (showing them in the future) would cause reported balances to be lower than the actual cleared balance.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.11.3",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/api": "^26.5.0",
-        "@actual-app/core": "^26.5.0",
+        "@actual-app/api": "^26.6.0",
+        "@actual-app/core": "^26.6.0",
         "@modelcontextprotocol/sdk": "1.27.1",
         "dotenv": "17.4.2",
         "express": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@actual-app/api": "^26.5.0",
-    "@actual-app/core": "^26.5.0",
+    "@actual-app/api": "^26.6.0",
+    "@actual-app/core": "^26.6.0",
     "@modelcontextprotocol/sdk": "1.27.1",
     "dotenv": "17.4.2",
     "express": "5.2.1",


### PR DESCRIPTION
### Summary
This PR upgrades `@actual-app/api` and `@actual-app/core` to version `^26.6.0` to resolve compatibility issues with Actual Budget Server v26.6.0+ databases.

Closes #181

### Changes
1. **Dependency Bump (1st fix):** Bumps `@actual-app/api` and `@actual-app/core` from `^26.5.0` to `^26.6.0` in `package.json` and `package-lock.json` to resolve the `out-of-sync-migrations` error when loading budgets migrated by Actual Server v26.6.0+.
2. **README Cleanup (2nd fix):** Removes the redundant "Fork Modifications" section from the `README.md` since the balance cutoff fix (`getAccountBalance` passing `2099-01-01`) has already been merged into this main upstream repository.

---
*This PR was prepared and tested with the assistance of Antigravity AI.*