### PR TITLE
feat(get-transactions): validate date range and add uncategorized filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1110,9 +1110,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1130,9 +1127,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1150,9 +1144,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1170,9 +1161,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1190,9 +1178,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1210,9 +1195,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3966,9 +3948,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3990,9 +3969,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4014,9 +3990,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4038,9 +4011,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/core/types/domain.ts
+++ b/src/core/types/domain.ts
@@ -14,6 +14,7 @@ export interface Transaction {
   account: string;
   date: string;
   amount: number;
+  is_parent?: boolean;
   payee?: string | null;
   payee_name?: string;
   category?: string;

--- a/src/tools/get-transactions/index.test.ts
+++ b/src/tools/get-transactions/index.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler } from './index.js';
+
+vi.mock('../../actual-api.js', () => ({
+  getTransactions: vi.fn(),
+  getCategories: vi.fn(),
+  getPayees: vi.fn(),
+}));
+
+import { getTransactions, getCategories, getPayees } from '../../actual-api.js';
+
+describe('get-transactions tool - uncategorized filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getPayees).mockResolvedValue([]);
+    vi.mocked(getCategories).mockResolvedValue([
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 'cat-dining', name: 'Dining', group_id: 'grp-1' } as any,
+    ]);
+  });
+
+  it('excludes split parents from uncategorized results', async () => {
+    vi.mocked(getTransactions).mockResolvedValue([
+      // Split parent: no category of its own, its child splits carry the categories.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 'parent-1', account: 'acc-1', date: '2024-05-01', amount: -3000, is_parent: true } as any,
+      // A categorized child split.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 'child-1', account: 'acc-1', date: '2024-05-01', amount: -3000, is_child: true, category: 'cat-dining' } as any,
+      // A genuinely uncategorized plain transaction.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 'plain-1', account: 'acc-1', date: '2024-05-02', amount: -1000, payee: null } as any,
+    ]);
+
+    const result = await handler({ accountId: 'acc-1', uncategorized: true });
+
+    expect(result.isError).toBeUndefined();
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('plain-1');
+    expect(text).not.toContain('parent-1');
+    expect(text).not.toContain('child-1');
+  });
+
+  it('excludes transfers from uncategorized results', async () => {
+    vi.mocked(getTransactions).mockResolvedValue([
+      // A transfer has no category but is categorized by design; it must not be treated as uncategorized.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 'transfer-1', account: 'acc-1', date: '2024-05-01', amount: -5000, transfer_id: 'tx-other' } as any,
+      // A genuinely uncategorized plain transaction.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { id: 'plain-1', account: 'acc-1', date: '2024-05-02', amount: -1000, payee: null } as any,
+    ]);
+
+    const result = await handler({ accountId: 'acc-1', uncategorized: true });
+
+    expect(result.isError).toBeUndefined();
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('plain-1');
+    expect(text).not.toContain('transfer-1');
+  });
+});

--- a/src/tools/get-transactions/index.ts
+++ b/src/tools/get-transactions/index.ts
@@ -34,7 +34,9 @@ export async function handler(args: GetTransactionsArgs): Promise<CallToolResult
     }
     if (uncategorized) {
       // # Reason: Uncategorized transactions have neither a resolved category name nor a raw category id.
-      filtered = filtered.filter((t) => !t.category_name && !t.category);
+      // Split parents carry no category themselves (their child splits do), and transfers are never
+      // categorized by design, so neither should be treated as uncategorized.
+      filtered = filtered.filter((t) => !t.category_name && !t.category && !t.is_parent && !t.transfer_id);
     }
     if (categoryName) {
       const lowerCategory = categoryName.toLowerCase();

--- a/src/tools/get-transactions/index.ts
+++ b/src/tools/get-transactions/index.ts
@@ -18,7 +18,8 @@ export const schema = {
 export async function handler(args: GetTransactionsArgs): Promise<CallToolResult> {
   try {
     const input = new GetTransactionsInputParser().parse(args);
-    const { accountId, startDate, endDate, minAmount, maxAmount, categoryName, payeeName, limit } = input;
+    const { accountId, startDate, endDate, minAmount, maxAmount, categoryName, uncategorized, payeeName, limit } =
+      input;
     const { startDate: start, endDate: end } = getDateRange(startDate, endDate);
 
     // Fetch transactions
@@ -30,6 +31,10 @@ export async function handler(args: GetTransactionsArgs): Promise<CallToolResult
     }
     if (maxAmount !== undefined) {
       filtered = filtered.filter((t) => t.amount <= maxAmount * 100);
+    }
+    if (uncategorized) {
+      // # Reason: Uncategorized transactions have neither a resolved category name nor a raw category id.
+      filtered = filtered.filter((t) => !t.category_name && !t.category);
     }
     if (categoryName) {
       const lowerCategory = categoryName.toLowerCase();
@@ -51,6 +56,7 @@ export async function handler(args: GetTransactionsArgs): Promise<CallToolResult
       startDate || endDate ? `Date range: ${startDate} to ${endDate}` : null,
       minAmount !== undefined ? `Min amount: $${minAmount.toFixed(2)}` : null,
       maxAmount !== undefined ? `Max amount: $${maxAmount.toFixed(2)}` : null,
+      uncategorized ? 'Category: (Uncategorized)' : null,
       categoryName ? `Category: ${categoryName}` : null,
       payeeName ? `Payee: ${payeeName}` : null,
     ]

--- a/src/tools/get-transactions/input-parser.test.ts
+++ b/src/tools/get-transactions/input-parser.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { GetTransactionsInputParser } from './input-parser.js';
+
+describe('GetTransactionsInputParser', () => {
+  const parser = new GetTransactionsInputParser();
+
+  it('parses a valid date range (happy path)', () => {
+    const result = parser.parse({
+      accountId: 'acct-1',
+      startDate: '2024-01-01',
+      endDate: '2024-03-31',
+    });
+
+    expect(result.startDate).toBe('2024-01-01');
+    expect(result.endDate).toBe('2024-03-31');
+  });
+
+  it('leaves dates undefined when not provided (edge case)', () => {
+    const result = parser.parse({ accountId: 'acct-1' });
+
+    expect(result.startDate).toBeUndefined();
+    expect(result.endDate).toBeUndefined();
+  });
+
+  it('parses the uncategorized flag', () => {
+    const result = parser.parse({ accountId: 'acct-1', uncategorized: true });
+
+    expect(result.uncategorized).toBe(true);
+  });
+
+  it('rejects malformed dates (failure case)', () => {
+    expect(() => parser.parse({ accountId: 'acct-1', startDate: '01/02/2024' })).toThrow(/YYYY-MM-DD/);
+  });
+
+  it('rejects an inverted date range', () => {
+    expect(() => parser.parse({ accountId: 'acct-1', startDate: '2024-05-01', endDate: '2024-04-01' })).toThrow(
+      /on or before/
+    );
+  });
+
+  it('requires an accountId', () => {
+    expect(() => parser.parse({ startDate: '2024-01-01' })).toThrow(/accountId/);
+  });
+});

--- a/src/tools/get-transactions/input-parser.ts
+++ b/src/tools/get-transactions/input-parser.ts
@@ -2,23 +2,53 @@
 
 import { GetTransactionsArgs } from '../../types.js';
 
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Validate that a value is either undefined or a well-formed YYYY-MM-DD date string.
+ *
+ * @param value - The raw argument value to check
+ * @param field - The field name used in error messages
+ * @returns The validated date string, or undefined if not provided
+ */
+function parseDate(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'string' || !DATE_PATTERN.test(value)) {
+    throw new Error(`${field} must be a string in YYYY-MM-DD format`);
+  }
+  return value;
+}
+
 export class GetTransactionsInputParser {
   parse(args: unknown): GetTransactionsArgs {
     if (!args || typeof args !== 'object') {
       throw new Error('Arguments must be an object');
     }
     const argsObj = args as Record<string, unknown>;
-    const { accountId, startDate, endDate, minAmount, maxAmount, categoryName, payeeName, limit } = argsObj;
+    const { accountId, startDate, endDate, minAmount, maxAmount, categoryName, uncategorized, payeeName, limit } =
+      argsObj;
     if (!accountId || typeof accountId !== 'string') {
       throw new Error('accountId is required and must be a string');
     }
+
+    const parsedStartDate = parseDate(startDate, 'startDate');
+    const parsedEndDate = parseDate(endDate, 'endDate');
+
+    // # Reason: An inverted range would silently return no transactions, so fail fast instead.
+    if (parsedStartDate && parsedEndDate && parsedStartDate > parsedEndDate) {
+      throw new Error('startDate must be on or before endDate');
+    }
+
     return {
       accountId,
-      startDate: typeof startDate === 'string' ? startDate : undefined,
-      endDate: typeof endDate === 'string' ? endDate : undefined,
+      startDate: parsedStartDate,
+      endDate: parsedEndDate,
       minAmount: typeof minAmount === 'number' ? minAmount : undefined,
       maxAmount: typeof maxAmount === 'number' ? maxAmount : undefined,
       categoryName: typeof categoryName === 'string' ? categoryName : undefined,
+      uncategorized: typeof uncategorized === 'boolean' ? uncategorized : undefined,
       payeeName: typeof payeeName === 'string' ? payeeName : undefined,
       limit: typeof limit === 'number' ? limit : undefined,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,14 +13,32 @@ export interface BudgetFile {
 
 // Type definitions for tool arguments
 export const GetTransactionsArgsSchema = z.object({
-  accountId: z.string(),
-  startDate: z.string().optional(),
-  endDate: z.string().optional(),
-  minAmount: z.number().optional(),
-  maxAmount: z.number().optional(),
-  categoryName: z.string().optional(),
-  payeeName: z.string().optional(),
-  limit: z.number().optional(),
+  accountId: z.string().describe('The ID of the account to fetch transactions for'),
+  startDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'startDate must be in YYYY-MM-DD format')
+    .optional()
+    .describe('Inclusive start of the date range in YYYY-MM-DD format. Defaults to 3 months ago.'),
+  endDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'endDate must be in YYYY-MM-DD format')
+    .optional()
+    .describe('Inclusive end of the date range in YYYY-MM-DD format. Defaults to today.'),
+  minAmount: z
+    .number()
+    .optional()
+    .describe('Only include transactions with an amount at or above this value (dollars)'),
+  maxAmount: z
+    .number()
+    .optional()
+    .describe('Only include transactions with an amount at or below this value (dollars)'),
+  categoryName: z.string().optional().describe('Only include transactions whose category name contains this text'),
+  uncategorized: z
+    .boolean()
+    .optional()
+    .describe('When true, only include transactions that have no category assigned (uncategorized)'),
+  payeeName: z.string().optional().describe('Only include transactions whose payee name contains this text'),
+  limit: z.number().optional().describe('Maximum number of transactions to return'),
 });
 
 export type GetTransactionsArgs = z.infer<typeof GetTransactionsArgsSchema>;


### PR DESCRIPTION
Harden the existing startDate/endDate filtering and add a dedicated uncategorized filter to the get-transactions tool.

- Add YYYY-MM-DD regex + descriptions to the schema fields so the format and defaults surface in the MCP tool's inputSchema
- Validate date format at runtime and reject inverted ranges
- Add an `uncategorized` boolean to return transactions with no category assigned
- Add input-parser tests covering happy path, edge, and failure cases