### PR TITLE
Better support for splitting transactions

### DIFF
--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -128,6 +128,24 @@ export async function getTransactions(accountId: string, start: string, end: str
 }
 
 /**
+ * Fetch a single transaction by ID with its subtransactions grouped.
+ *
+ * Uses Actual's AQL query builder so we can look one transaction up directly
+ * (the public getTransactions requires an account id and date range). Returns
+ * null when no transaction matches the id.
+ *
+ * @param id - The transaction id to look up
+ * @returns The grouped transaction (with a subtransactions array) or null
+ */
+export async function getTransactionById(id: string): Promise<TransactionEntity | null> {
+  await initActualApi();
+  const result = (await api.aqlQuery(
+    api.q('transactions').filter({ id }).select(['*']).options({ splits: 'grouped' })
+  )) as { data: TransactionEntity[] };
+  return result?.data?.[0] ?? null;
+}
+
+/**
  * Get all rules (ensures API is initialized)
  */
 export async function getRules(): Promise<RuleEntity[]> {

--- a/src/tools/update-transaction/build-split.test.ts
+++ b/src/tools/update-transaction/build-split.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import { isSplitTransaction, buildSplitConversion } from './build-split.js';
+
+describe('isSplitTransaction', () => {
+  it('should return true when is_parent is set', () => {
+    expect(isSplitTransaction({ is_parent: true })).toBe(true);
+  });
+
+  it('should return true when subtransactions are present', () => {
+    expect(isSplitTransaction({ subtransactions: [{ amount: -100 }] })).toBe(true);
+  });
+
+  it('should return false for a plain transaction', () => {
+    expect(isSplitTransaction({ is_parent: false, subtransactions: [] })).toBe(false);
+  });
+
+  it('should return false when nothing indicates a split', () => {
+    expect(isSplitTransaction({})).toBe(false);
+  });
+
+  it('should return false for a null transaction', () => {
+    expect(isSplitTransaction(null)).toBe(false);
+  });
+});
+
+describe('buildSplitConversion', () => {
+  // Deterministic id factory so we can assert exact output.
+  const makeGenerator = (): (() => string) => {
+    let n = 0;
+    return () => `generated-${++n}`;
+  };
+
+  it('should build fully-formed children that inherit account and date', () => {
+    const result = buildSplitConversion({
+      parentId: 'txn-1',
+      account: 'acc-1',
+      date: '2024-05-01',
+      subtransactions: [
+        { amount: -3000, category: 'cat-a' },
+        { amount: -2000, category: 'cat-b', notes: 'Soap' },
+      ],
+      generateId: makeGenerator(),
+    });
+
+    expect(result).toEqual({
+      is_parent: true,
+      category: null,
+      subtransactions: [
+        {
+          id: 'generated-1',
+          account: 'acc-1',
+          date: '2024-05-01',
+          amount: -3000,
+          parent_id: 'txn-1',
+          is_child: true,
+          sort_order: 0,
+          category: 'cat-a',
+        },
+        {
+          id: 'generated-2',
+          account: 'acc-1',
+          date: '2024-05-01',
+          amount: -2000,
+          parent_id: 'txn-1',
+          is_child: true,
+          sort_order: -1,
+          category: 'cat-b',
+          notes: 'Soap',
+        },
+      ],
+    });
+  });
+
+  it('should preserve caller-provided child ids and generate the rest', () => {
+    const result = buildSplitConversion({
+      parentId: 'txn-1',
+      account: 'acc-1',
+      date: '2024-05-01',
+      subtransactions: [{ id: 'existing-child', amount: -1000 }, { amount: -500 }],
+      generateId: makeGenerator(),
+    });
+
+    const children = result.subtransactions as Array<{ id: string }>;
+    expect(children[0].id).toBe('existing-child');
+    expect(children[1].id).toBe('generated-1');
+  });
+
+  it('should omit optional category and notes when not supplied', () => {
+    const result = buildSplitConversion({
+      parentId: 'txn-1',
+      account: 'acc-1',
+      date: '2024-05-01',
+      subtransactions: [{ amount: -1000 }],
+      generateId: makeGenerator(),
+    });
+
+    const child = (result.subtransactions as Array<Record<string, unknown>>)[0];
+    expect(child).not.toHaveProperty('category');
+    expect(child).not.toHaveProperty('notes');
+  });
+
+  it('should propagate the parent payee to every child when provided', () => {
+    const result = buildSplitConversion({
+      parentId: 'txn-1',
+      account: 'acc-1',
+      date: '2024-05-01',
+      payee: 'payee-9',
+      subtransactions: [{ amount: -1000 }, { amount: -500 }],
+      generateId: makeGenerator(),
+    });
+
+    const payees = (result.subtransactions as Array<{ payee?: string }>).map((c) => c.payee);
+    expect(payees).toEqual(['payee-9', 'payee-9']);
+  });
+
+  it('should omit payee on children when the parent has none', () => {
+    const withNull = buildSplitConversion({
+      parentId: 'txn-1',
+      account: 'acc-1',
+      date: '2024-05-01',
+      payee: null,
+      subtransactions: [{ amount: -1000 }],
+      generateId: makeGenerator(),
+    });
+    const withUndefined = buildSplitConversion({
+      parentId: 'txn-1',
+      account: 'acc-1',
+      date: '2024-05-01',
+      subtransactions: [{ amount: -1000 }],
+      generateId: makeGenerator(),
+    });
+
+    expect((withNull.subtransactions as Array<Record<string, unknown>>)[0]).not.toHaveProperty('payee');
+    expect((withUndefined.subtransactions as Array<Record<string, unknown>>)[0]).not.toHaveProperty('payee');
+  });
+
+  it('should number sort_order in descending offsets to preserve order', () => {
+    const result = buildSplitConversion({
+      parentId: 'txn-1',
+      account: 'acc-1',
+      date: '2024-05-01',
+      subtransactions: [{ amount: -1 }, { amount: -2 }, { amount: -3 }],
+      generateId: makeGenerator(),
+    });
+
+    const orders = (result.subtransactions as Array<{ sort_order: number }>).map((c) => c.sort_order);
+    expect(orders).toEqual([0, -1, -2]);
+  });
+});

--- a/src/tools/update-transaction/build-split.test.ts
+++ b/src/tools/update-transaction/build-split.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'vitest';
-import { isSplitTransaction, buildSplitConversion } from './build-split.js';
+import { isSplitTransaction, buildSplitConversion, sumSubtransactions } from './build-split.js';
+
+describe('sumSubtransactions', () => {
+  it('should sum the child amounts', () => {
+    expect(sumSubtransactions([{ amount: -3000 }, { amount: -2000 }])).toBe(-5000);
+  });
+
+  it('should return 0 for an empty array', () => {
+    expect(sumSubtransactions([])).toBe(0);
+  });
+
+  it('should handle a mix of positive and negative amounts', () => {
+    expect(sumSubtransactions([{ amount: -3000 }, { amount: 500 }])).toBe(-2500);
+  });
+});
 
 describe('isSplitTransaction', () => {
   it('should return true when is_parent is set', () => {

--- a/src/tools/update-transaction/build-split.ts
+++ b/src/tools/update-transaction/build-split.ts
@@ -23,6 +23,19 @@ export function isSplitTransaction(txn: ExistingSplitState | null): boolean {
 }
 
 /**
+ * Sum the amounts of a set of subtransactions.
+ *
+ * Amounts are integer minor units, so this is exact integer arithmetic with no
+ * floating-point rounding concerns.
+ *
+ * @param subtransactions - The subtransactions to total
+ * @returns The combined amount
+ */
+export function sumSubtransactions(subtransactions: UpdateSubtransaction[]): number {
+  return subtransactions.reduce((total, sub) => total + sub.amount, 0);
+}
+
+/**
  * Build the update payload fields required to convert a plain (non-split)
  * transaction into a split.
  *

--- a/src/tools/update-transaction/build-split.ts
+++ b/src/tools/update-transaction/build-split.ts
@@ -1,0 +1,82 @@
+import type { UpdateSubtransaction } from '../../types.js';
+
+/**
+ * Minimal shape needed to reason about an existing transaction's split state.
+ */
+export interface ExistingSplitState {
+  is_parent?: boolean;
+  subtransactions?: unknown[];
+}
+
+/**
+ * Determine whether a transaction is already a split (i.e. it already has child
+ * subtransactions). Actual's `updateTransaction` only propagates the parent
+ * account to children when the transaction is already a split, so this decides
+ * whether we can pass subtransactions through untouched.
+ *
+ * @param txn - The existing transaction (grouped), or null if it couldn't be loaded
+ * @returns True when the transaction already has children
+ */
+export function isSplitTransaction(txn: ExistingSplitState | null): boolean {
+  if (!txn) return false;
+  return txn.is_parent === true || (Array.isArray(txn.subtransactions) && txn.subtransactions.length > 0);
+}
+
+/**
+ * Build the update payload fields required to convert a plain (non-split)
+ * transaction into a split.
+ *
+ * Actual's grouped update path does not synthesize child rows for a transaction
+ * that isn't already a split — it inserts whatever is handed to it verbatim,
+ * which fails with `"account" is required` because children carry no account.
+ * We therefore construct fully-formed children here, mirroring Actual's internal
+ * `makeSplitTransaction`/`makeChild`: each child inherits the parent's account,
+ * date and payee and is linked back via `parent_id`/`is_child`. The parent is
+ * marked `is_parent` and its own category is cleared (categories live on the
+ * children).
+ *
+ * @param params.parentId - The id of the transaction being converted
+ * @param params.account - The account the parent belongs to (children inherit it)
+ * @param params.date - The parent's date (children inherit it)
+ * @param params.payee - The parent's payee id, propagated to each child when set
+ * @param params.subtransactions - The requested subtransactions from the caller
+ * @param params.generateId - Factory for new child ids (injected for testability)
+ * @returns Partial update fields to merge into the transaction update payload
+ */
+export function buildSplitConversion(params: {
+  parentId: string;
+  account: string;
+  date: string;
+  payee?: string | null;
+  subtransactions: UpdateSubtransaction[];
+  generateId: () => string;
+}): Record<string, unknown> {
+  const { parentId, account, date, payee, subtransactions, generateId } = params;
+
+  const children = subtransactions.map((sub, index) => {
+    const child: Record<string, unknown> = {
+      id: sub.id ?? generateId(),
+      account,
+      date,
+      amount: sub.amount,
+      parent_id: parentId,
+      is_child: true,
+      // Reason: preserve caller ordering; Actual's makeSplitTransaction uses the
+      // same 0-based descending offsets so children keep their relative order.
+      sort_order: 0 - index,
+    };
+    // Reason: split children should carry the parent's payee so they display
+    // consistently; only set it when the parent actually has one.
+    if (payee != null) child.payee = payee;
+    if (sub.category !== undefined) child.category = sub.category;
+    if (sub.notes !== undefined) child.notes = sub.notes;
+    return child;
+  });
+
+  return {
+    is_parent: true,
+    // Reason: a split parent holds no category of its own; the children carry them.
+    category: null,
+    subtransactions: children,
+  };
+}

--- a/src/tools/update-transaction/index.test.ts
+++ b/src/tools/update-transaction/index.test.ts
@@ -394,6 +394,92 @@ describe('update-transaction tool', () => {
       });
     });
 
+    it('should reject a split whose amounts do not sum to the existing total', async () => {
+      vi.mocked(getTransactionById).mockResolvedValue({
+        id: 'txn-123',
+        account: 'acc-parent',
+        date: '2024-05-01',
+        amount: -5000,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      const result = await handler({
+        id: 'txn-123',
+        subtransactions: [
+          { amount: -3000, category: 'cat-a' },
+          { amount: -1000, category: 'cat-b' },
+        ],
+      });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('must sum to the transaction total');
+      expect(text).toContain('-4000');
+      expect(text).toContain('-5000');
+      expect(updateTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should validate against a new amount set on the same update', async () => {
+      vi.mocked(getTransactionById).mockResolvedValue({
+        id: 'txn-123',
+        account: 'acc-parent',
+        date: '2024-05-01',
+        amount: -5000,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      const result = await handler({
+        id: 'txn-123',
+        amount: -4000,
+        subtransactions: [
+          { amount: -3000, category: 'cat-a' },
+          { amount: -1000, category: 'cat-b' },
+        ],
+      });
+
+      // Children sum to -4000, which matches the new amount even though it
+      // differs from the old total, so the update should proceed.
+      expect(result.isError).toBeUndefined();
+      expect(updateTransaction).toHaveBeenCalled();
+    });
+
+    it('should reject a mismatched split on an already-split transaction', async () => {
+      vi.mocked(getTransactionById).mockResolvedValue({
+        id: 'txn-123',
+        account: 'acc-parent',
+        date: '2024-05-01',
+        amount: -5000,
+        is_parent: true,
+        subtransactions: [{ id: 'child-1', amount: -5000 }],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      const result = await handler({
+        id: 'txn-123',
+        subtransactions: [
+          { id: 'child-1', amount: -3000, category: 'cat-a' },
+          { amount: -1000, category: 'cat-b' },
+        ],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(updateTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should not validate when the total cannot be determined', async () => {
+      vi.mocked(updateTransaction).mockResolvedValue(undefined);
+      // Transaction can't be loaded and no amount supplied → total unknown.
+      vi.mocked(getTransactionById).mockResolvedValue(null);
+
+      const result = await handler({
+        id: 'txn-123',
+        subtransactions: [{ amount: -3000, category: 'cat-a' }],
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(updateTransaction).toHaveBeenCalled();
+    });
+
     it('should not look up the transaction when no subtransactions are provided', async () => {
       vi.mocked(updateTransaction).mockResolvedValue(undefined);
 

--- a/src/tools/update-transaction/index.test.ts
+++ b/src/tools/update-transaction/index.test.ts
@@ -4,13 +4,17 @@ import { handler, schema } from './index.js';
 // CRITICAL: Mock before imports
 vi.mock('../../actual-api.js', () => ({
   updateTransaction: vi.fn(),
+  getTransactionById: vi.fn(),
 }));
 
-import { updateTransaction } from '../../actual-api.js';
+import { updateTransaction, getTransactionById } from '../../actual-api.js';
 
 describe('update-transaction tool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: transaction lookup returns null so subtransaction payloads pass
+    // through untouched. Conversion tests override this per case.
+    vi.mocked(getTransactionById).mockResolvedValue(null);
   });
 
   describe('schema', () => {
@@ -209,6 +213,207 @@ describe('update-transaction tool', () => {
         cleared: true,
       });
       expect((result.content[0] as { text: string }).text).toContain('Updated fields:');
+    });
+  });
+
+  describe('handler - split conversion', () => {
+    it('should convert a plain transaction into a split', async () => {
+      vi.mocked(updateTransaction).mockResolvedValue(undefined);
+      vi.mocked(getTransactionById).mockResolvedValue({
+        id: 'txn-123',
+        account: 'acc-parent',
+        date: '2024-05-01',
+        amount: -5000,
+        is_parent: false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      const args = {
+        id: 'txn-123',
+        subtransactions: [
+          { amount: -3000, category: 'cat-groceries' },
+          { amount: -2000, category: 'cat-household', notes: 'Soap' },
+        ],
+      };
+
+      const result = await handler(args);
+
+      expect(getTransactionById).toHaveBeenCalledWith('txn-123');
+      expect(updateTransaction).toHaveBeenCalledWith('txn-123', {
+        is_parent: true,
+        category: null,
+        subtransactions: [
+          {
+            id: expect.any(String),
+            account: 'acc-parent',
+            date: '2024-05-01',
+            amount: -3000,
+            parent_id: 'txn-123',
+            is_child: true,
+            sort_order: 0,
+            category: 'cat-groceries',
+          },
+          {
+            id: expect.any(String),
+            account: 'acc-parent',
+            date: '2024-05-01',
+            amount: -2000,
+            parent_id: 'txn-123',
+            is_child: true,
+            sort_order: -1,
+            category: 'cat-household',
+            notes: 'Soap',
+          },
+        ],
+      });
+      expect(result.isError).toBeUndefined();
+      // Confirmation reflects the caller-facing field, not the rewritten internals.
+      expect((result.content[0] as { text: string }).text).toContain('Updated fields: subtransactions');
+    });
+
+    it('should give children a moved account and new date when provided on the update', async () => {
+      vi.mocked(updateTransaction).mockResolvedValue(undefined);
+      vi.mocked(getTransactionById).mockResolvedValue({
+        id: 'txn-123',
+        account: 'acc-old',
+        date: '2024-05-01',
+        amount: -5000,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      await handler({
+        id: 'txn-123',
+        account: 'acc-new',
+        date: '2024-06-15',
+        subtransactions: [{ amount: -5000, category: 'cat-x' }],
+      });
+
+      const [, payload] = vi.mocked(updateTransaction).mock.calls[0];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const children = (payload as any).subtransactions;
+      expect(children[0]).toMatchObject({
+        account: 'acc-new',
+        date: '2024-06-15',
+        parent_id: 'txn-123',
+        is_child: true,
+      });
+    });
+
+    it('should propagate the parent payee to converted children', async () => {
+      vi.mocked(updateTransaction).mockResolvedValue(undefined);
+      vi.mocked(getTransactionById).mockResolvedValue({
+        id: 'txn-123',
+        account: 'acc-parent',
+        date: '2024-05-01',
+        amount: -5000,
+        payee: 'payee-parent',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      await handler({
+        id: 'txn-123',
+        subtransactions: [
+          { amount: -3000, category: 'cat-a' },
+          { amount: -2000, category: 'cat-b' },
+        ],
+      });
+
+      const [, payload] = vi.mocked(updateTransaction).mock.calls[0];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const children = (payload as any).subtransactions;
+      expect(children.map((c: { payee?: string }) => c.payee)).toEqual(['payee-parent', 'payee-parent']);
+    });
+
+    it('should propagate a payee newly set on the update to children', async () => {
+      vi.mocked(updateTransaction).mockResolvedValue(undefined);
+      vi.mocked(getTransactionById).mockResolvedValue({
+        id: 'txn-123',
+        account: 'acc-parent',
+        date: '2024-05-01',
+        amount: -5000,
+        payee: 'payee-old',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      await handler({
+        id: 'txn-123',
+        payee: 'payee-new',
+        subtransactions: [{ amount: -5000, category: 'cat-a' }],
+      });
+
+      const [, payload] = vi.mocked(updateTransaction).mock.calls[0];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((payload as any).subtransactions[0].payee).toBe('payee-new');
+    });
+
+    it('should preserve caller-provided subtransaction ids when converting', async () => {
+      vi.mocked(updateTransaction).mockResolvedValue(undefined);
+      vi.mocked(getTransactionById).mockResolvedValue({
+        id: 'txn-123',
+        account: 'acc-parent',
+        date: '2024-05-01',
+        amount: -1000,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      await handler({
+        id: 'txn-123',
+        subtransactions: [{ id: 'keep-me', amount: -1000, category: 'cat-a' }],
+      });
+
+      const [, payload] = vi.mocked(updateTransaction).mock.calls[0];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((payload as any).subtransactions[0].id).toBe('keep-me');
+    });
+
+    it('should pass subtransactions through unchanged for an already-split transaction', async () => {
+      vi.mocked(updateTransaction).mockResolvedValue(undefined);
+      vi.mocked(getTransactionById).mockResolvedValue({
+        id: 'txn-123',
+        account: 'acc-parent',
+        date: '2024-05-01',
+        amount: -5000,
+        is_parent: true,
+        subtransactions: [{ id: 'child-1', amount: -5000 }],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      await handler({
+        id: 'txn-123',
+        subtransactions: [
+          { id: 'child-1', amount: -3000, category: 'cat-a' },
+          { amount: -2000, category: 'cat-b' },
+        ],
+      });
+
+      expect(updateTransaction).toHaveBeenCalledWith('txn-123', {
+        subtransactions: [
+          { id: 'child-1', amount: -3000, category: 'cat-a' },
+          { amount: -2000, category: 'cat-b' },
+        ],
+      });
+    });
+
+    it('should not look up the transaction when no subtransactions are provided', async () => {
+      vi.mocked(updateTransaction).mockResolvedValue(undefined);
+
+      await handler({ id: 'txn-123', amount: -1000 });
+
+      expect(getTransactionById).not.toHaveBeenCalled();
+    });
+
+    it('should leave the payload untouched when the transaction cannot be loaded', async () => {
+      vi.mocked(updateTransaction).mockResolvedValue(undefined);
+      vi.mocked(getTransactionById).mockResolvedValue(null);
+
+      await handler({
+        id: 'txn-missing',
+        subtransactions: [{ amount: -1000, category: 'cat-a' }],
+      });
+
+      expect(updateTransaction).toHaveBeenCalledWith('txn-missing', {
+        subtransactions: [{ amount: -1000, category: 'cat-a' }],
+      });
     });
   });
 

--- a/src/tools/update-transaction/index.ts
+++ b/src/tools/update-transaction/index.ts
@@ -9,12 +9,12 @@ import {
   type UpdateSubtransaction,
   ToolInput,
 } from '../../types.js';
-import { isSplitTransaction, buildSplitConversion } from './build-split.js';
+import { isSplitTransaction, buildSplitConversion, sumSubtransactions } from './build-split.js';
 
 export const schema = {
   name: 'update-transaction',
   description:
-    'Update an existing transaction. Can modify date, amount, payee, category, notes, cleared status, and subtransactions. Providing subtransactions on a non-split transaction converts it into a split; the children inherit the parent account and date automatically.',
+    'Update an existing transaction. Can modify date, amount, payee, category, notes, cleared status, and subtransactions. Providing subtransactions on a non-split transaction converts it into a split; the children inherit the parent account and date automatically. Subtransaction amounts must sum to the transaction total or the update is rejected.',
   inputSchema: toJSONSchema(UpdateTransactionArgsSchema) as ToolInput,
 };
 
@@ -44,7 +44,13 @@ export async function handler(args: UpdateTransactionArgs): Promise<CallToolResu
     // the payload, so the confirmation message reflects what the user asked for.
     const updatedFields = Object.keys(filteredUpdateData).join(', ');
 
-    await applySplitConversion(transactionId, filteredUpdateData);
+    const subtransactionError = await prepareSubtransactions(transactionId, filteredUpdateData);
+    if (subtransactionError) {
+      return {
+        content: [{ type: 'text', text: subtransactionError }],
+        isError: true,
+      };
+    }
 
     await updateTransaction(transactionId, filteredUpdateData);
 
@@ -55,25 +61,50 @@ export async function handler(args: UpdateTransactionArgs): Promise<CallToolResu
 }
 
 /**
- * When subtransactions are supplied, ensure the update payload will produce a
- * valid split.
+ * Validate and, when necessary, rewrite supplied subtransactions before the
+ * update is sent to Actual.
  *
- * Actual only propagates the parent account to children when the transaction is
- * already a split. For a plain transaction we must rewrite the payload into a
- * proper conversion (see build-split.ts). Already-split transactions and empty
- * subtransaction arrays are left untouched — Actual handles those paths itself.
- * If the transaction can't be loaded we also leave the payload alone rather than
- * guess at an account.
+ * Two responsibilities:
+ *  1. Reject splits whose child amounts don't sum to the parent total. Actual
+ *     would otherwise accept the update and only surface the mismatch as an
+ *     error in the app, so we fail loudly here instead.
+ *  2. Convert a plain transaction into a split. Actual only propagates the parent
+ *     account to children when the transaction is already a split, so a plain
+ *     transaction's children must be rewritten into fully-formed rows (see
+ *     build-split.ts). Already-split transactions and empty arrays are left
+ *     untouched — Actual handles those paths itself. If the transaction can't be
+ *     loaded we leave the payload alone rather than guess at an account.
  *
  * @param transactionId - The id of the transaction being updated
  * @param updateData - The filtered update payload, mutated in place when converting
+ * @returns An error message when the split is invalid, otherwise null
  */
-async function applySplitConversion(transactionId: string, updateData: Record<string, unknown>): Promise<void> {
+async function prepareSubtransactions(
+  transactionId: string,
+  updateData: Record<string, unknown>
+): Promise<string | null> {
   const requestedSubs = updateData.subtransactions;
-  if (!Array.isArray(requestedSubs) || requestedSubs.length === 0) return;
+  if (!Array.isArray(requestedSubs) || requestedSubs.length === 0) return null;
+  const subtransactions = requestedSubs as UpdateSubtransaction[];
 
   const existing = await getTransactionById(transactionId);
-  if (!existing || isSplitTransaction(existing)) return;
+
+  // Validate the split totals against the parent amount. Prefer a new amount set
+  // on this update, otherwise the transaction's current amount. When neither is
+  // known (transaction not found and no amount supplied) we can't validate.
+  const parentTotal = (updateData.amount as number | undefined) ?? existing?.amount;
+  if (parentTotal !== undefined) {
+    const childrenTotal = sumSubtransactions(subtransactions);
+    if (childrenTotal !== parentTotal) {
+      return (
+        `Subtransaction amounts must sum to the transaction total. ` +
+        `The subtransactions add up to ${childrenTotal} but the transaction total is ${parentTotal} ` +
+        `(a difference of ${parentTotal - childrenTotal}). Amounts are integers in minor units.`
+      );
+    }
+  }
+
+  if (!existing || isSplitTransaction(existing)) return null;
 
   const account = (updateData.account as string | undefined) ?? existing.account;
   const date = (updateData.date as string | undefined) ?? existing.date;
@@ -89,8 +120,9 @@ async function applySplitConversion(transactionId: string, updateData: Record<st
       account,
       date,
       payee,
-      subtransactions: requestedSubs as UpdateSubtransaction[],
+      subtransactions,
       generateId: randomUUID,
     })
   );
+  return null;
 }

--- a/src/tools/update-transaction/index.ts
+++ b/src/tools/update-transaction/index.ts
@@ -1,13 +1,20 @@
+import { randomUUID } from 'node:crypto';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { toJSONSchema } from 'zod';
 import { success, errorFromCatch } from '../../utils/response.js';
-import { updateTransaction } from '../../actual-api.js';
-import { UpdateTransactionArgsSchema, type UpdateTransactionArgs, ToolInput } from '../../types.js';
+import { updateTransaction, getTransactionById } from '../../actual-api.js';
+import {
+  UpdateTransactionArgsSchema,
+  type UpdateTransactionArgs,
+  type UpdateSubtransaction,
+  ToolInput,
+} from '../../types.js';
+import { isSplitTransaction, buildSplitConversion } from './build-split.js';
 
 export const schema = {
   name: 'update-transaction',
   description:
-    'Update an existing transaction. Can modify date, amount, payee, category, notes, cleared status, and subtransactions.',
+    'Update an existing transaction. Can modify date, amount, payee, category, notes, cleared status, and subtransactions. Providing subtransactions on a non-split transaction converts it into a split; the children inherit the parent account and date automatically.',
   inputSchema: toJSONSchema(UpdateTransactionArgsSchema) as ToolInput,
 };
 
@@ -33,11 +40,57 @@ export async function handler(args: UpdateTransactionArgs): Promise<CallToolResu
       };
     }
 
+    // Capture the caller-facing field names before any split conversion rewrites
+    // the payload, so the confirmation message reflects what the user asked for.
+    const updatedFields = Object.keys(filteredUpdateData).join(', ');
+
+    await applySplitConversion(transactionId, filteredUpdateData);
+
     await updateTransaction(transactionId, filteredUpdateData);
 
-    const updatedFields = Object.keys(filteredUpdateData).join(', ');
     return success(`Successfully updated transaction ${transactionId}. Updated fields: ${updatedFields}`);
   } catch (error) {
     return errorFromCatch(error);
   }
+}
+
+/**
+ * When subtransactions are supplied, ensure the update payload will produce a
+ * valid split.
+ *
+ * Actual only propagates the parent account to children when the transaction is
+ * already a split. For a plain transaction we must rewrite the payload into a
+ * proper conversion (see build-split.ts). Already-split transactions and empty
+ * subtransaction arrays are left untouched — Actual handles those paths itself.
+ * If the transaction can't be loaded we also leave the payload alone rather than
+ * guess at an account.
+ *
+ * @param transactionId - The id of the transaction being updated
+ * @param updateData - The filtered update payload, mutated in place when converting
+ */
+async function applySplitConversion(transactionId: string, updateData: Record<string, unknown>): Promise<void> {
+  const requestedSubs = updateData.subtransactions;
+  if (!Array.isArray(requestedSubs) || requestedSubs.length === 0) return;
+
+  const existing = await getTransactionById(transactionId);
+  if (!existing || isSplitTransaction(existing)) return;
+
+  const account = (updateData.account as string | undefined) ?? existing.account;
+  const date = (updateData.date as string | undefined) ?? existing.date;
+  // Prefer a payee explicitly set on this update, otherwise inherit the
+  // transaction's current payee. (payee_name is resolved server-side and can't
+  // be propagated to children, which are inserted as raw transaction rows.)
+  const payee = (updateData.payee as string | undefined) ?? existing.payee;
+
+  Object.assign(
+    updateData,
+    buildSplitConversion({
+      parentId: transactionId,
+      account,
+      date,
+      payee,
+      subtransactions: requestedSubs as UpdateSubtransaction[],
+      generateId: randomUUID,
+    })
+  );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,7 +112,7 @@ export const UpdateTransactionArgsSchema = z.object({
     .array(UpdateSubtransactionSchema)
     .optional()
     .describe(
-      "An array of subtransactions for a split transaction. If the transaction is not already a split, providing these converts it into one (children inherit the parent's account and date). Replaces existing subtransactions. Do not set an account on subtransactions. If amounts don't equal total amount, API call will succeed but error will show in app"
+      "An array of subtransactions for a split transaction. If the transaction is not already a split, providing these converts it into one (children inherit the parent's account and date). Replaces existing subtransactions. Do not set an account on subtransactions. The amounts must sum to the transaction total (a new amount on this update if provided, otherwise the existing total) or the update is rejected."
     ),
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,7 +112,7 @@ export const UpdateTransactionArgsSchema = z.object({
     .array(UpdateSubtransactionSchema)
     .optional()
     .describe(
-      "An array of subtransactions for a split transaction. Replaces existing subtransactions. If amounts don't equal total amount, API call will succeed but error will show in app"
+      "An array of subtransactions for a split transaction. If the transaction is not already a split, providing these converts it into one (children inherit the parent's account and date). Replaces existing subtransactions. Do not set an account on subtransactions. If amounts don't equal total amount, API call will succeed but error will show in app"
     ),
 });
 


### PR DESCRIPTION
Allows agents to automatically split transactions without having to create new separate subtransactions first. Instead just submit an update-transaction tool call with subtransactions and the MCP layer handles creating the new subtransactions.