### PR TITLE
fix: re-sync with the server instead of serving the startup snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ export ACTUAL_PASSWORD="your-password"
 
 # Specific budget to use (optional)
 export ACTUAL_BUDGET_SYNC_ID="your-budget-id"
+
+# How long downloaded data stays fresh before the server re-syncs, in ms
+# (default: 60000). Use 0 to sync before every call, or -1 to never sync.
+export ACTUAL_SYNC_TTL_MS="60000"
 ```
 
 Optional: separate encryption budget password

--- a/src/actual-api.test.ts
+++ b/src/actual-api.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@actual-app/api', () => ({
+  init: vi.fn(),
+  getBudgets: vi.fn(),
+  downloadBudget: vi.fn(),
+  sync: vi.fn(),
+  shutdown: vi.fn(),
+}));
+
+import * as api from '@actual-app/api';
+import { initActualApi, shutdownActualApi } from './actual-api.js';
+
+describe('initActualApi syncing', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(api.getBudgets).mockResolvedValue([{ id: 'budget-1', cloudFileId: 'cloud-1' }] as never);
+    process.env.ACTUAL_SERVER_URL = 'https://example.invalid';
+    process.env.ACTUAL_PASSWORD = 'secret';
+    delete process.env.ACTUAL_SYNC_TTL_MS;
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await shutdownActualApi();
+  });
+
+  it('downloads the budget once and does not sync on the first call', async () => {
+    await initActualApi();
+
+    expect(api.downloadBudget).toHaveBeenCalledTimes(1);
+    expect(api.sync).not.toHaveBeenCalled();
+  });
+
+  it('does not re-download the budget on later calls', async () => {
+    await initActualApi();
+    vi.advanceTimersByTime(120_000);
+    await initActualApi();
+
+    expect(api.downloadBudget).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs once the data is older than the TTL', async () => {
+    await initActualApi();
+
+    vi.advanceTimersByTime(30_000);
+    await initActualApi();
+    expect(api.sync).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(31_000);
+    await initActualApi();
+    expect(api.sync).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours ACTUAL_SYNC_TTL_MS', async () => {
+    process.env.ACTUAL_SYNC_TTL_MS = '0';
+    await initActualApi();
+
+    await initActualApi();
+    await initActualApi();
+    expect(api.sync).toHaveBeenCalledTimes(2);
+  });
+
+  it('never syncs when ACTUAL_SYNC_TTL_MS is negative', async () => {
+    process.env.ACTUAL_SYNC_TTL_MS = '-1';
+    await initActualApi();
+
+    vi.advanceTimersByTime(600_000);
+    await initActualApi();
+    expect(api.sync).not.toHaveBeenCalled();
+  });
+
+  it('keeps serving when a sync fails', async () => {
+    await initActualApi();
+    vi.mocked(api.sync).mockRejectedValueOnce(new Error('server unreachable'));
+
+    vi.advanceTimersByTime(61_000);
+    await expect(initActualApi()).resolves.toBeUndefined();
+  });
+});

--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -8,17 +8,59 @@ import { RuleEntity, TransactionEntity } from '@actual-app/core/types/models';
 import { ImportTransactionEntity } from '@actual-app/core/types/models/import-transaction';
 
 const DEFAULT_DATA_DIR: string = path.resolve(os.homedir() || '.', '.actual');
+const DEFAULT_SYNC_TTL_MS = 60_000;
 
 // API initialization state
 let initialized = false;
 let initializing = false;
 let initializationError: Error | null = null;
+let lastSyncAt = 0;
+
+/**
+ * How long downloaded data is considered fresh, in milliseconds.
+ * Set ACTUAL_SYNC_TTL_MS to 0 to sync before every call, or to a negative
+ * value to disable automatic syncing entirely.
+ */
+function syncTtlMs(): number {
+  const raw = process.env.ACTUAL_SYNC_TTL_MS;
+  if (raw === undefined || raw === '') return DEFAULT_SYNC_TTL_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : DEFAULT_SYNC_TTL_MS;
+}
+
+/**
+ * Pull changes made elsewhere (web UI, mobile, other clients) into the local
+ * budget file.
+ *
+ * `downloadBudget` only runs once, at initialization, so without this a
+ * long-running server keeps answering from the snapshot it started with:
+ * transactions added later are silently invisible. That is especially easy to
+ * hit over SSE/HTTP, where a single process serves requests for days.
+ *
+ * A failed sync is logged but not thrown: answering from slightly stale data
+ * beats failing the tool call outright.
+ */
+async function syncIfStale(): Promise<void> {
+  const ttl = syncTtlMs();
+  if (ttl < 0) return;
+  if (Date.now() - lastSyncAt < ttl) return;
+
+  try {
+    await api.sync();
+    lastSyncAt = Date.now();
+  } catch (error) {
+    console.error('Failed to sync with Actual server, continuing with local data:', error);
+  }
+}
 
 /**
  * Initialize the Actual Budget API
  */
 export async function initActualApi(): Promise<void> {
-  if (initialized) return;
+  if (initialized) {
+    await syncIfStale();
+    return;
+  }
   if (initializing) {
     // Wait for initialization to complete if already in progress
     while (initializing) {
@@ -59,6 +101,7 @@ export async function initActualApi(): Promise<void> {
     );
 
     initialized = true;
+    lastSyncAt = Date.now();
     console.error('Actual Budget API initialized successfully');
   } catch (error) {
     console.error('Failed to initialize Actual Budget API:', error);
@@ -80,6 +123,7 @@ export async function shutdownActualApi(): Promise<void> {
     console.error('Error shutting down Actual Budget API:', err);
   } finally {
     initialized = false;
+    lastSyncAt = 0;
   }
 }
 


### PR DESCRIPTION
## The problem

`downloadBudget()` runs once, during initialization, and nothing ever calls `api.sync()` afterwards. A long-running server therefore keeps answering from the snapshot it started with — transactions added from the web UI, the mobile app, or another client stay invisible until the process restarts.

Over stdio this is easy to miss, since the process is short-lived. In `--sse` mode it bites hard: one process can serve requests for days. I hit this running the server as a remote connector, where it had been answering budget questions from a snapshot several hours old.

The failure mode is the bad kind — silent. Tools return confident, well-formatted, stale answers, and nothing in the output suggests the data is old.

## The fix

`initActualApi()` is already called by every tool, so re-syncing there covers the whole server without touching a single tool.

Data is treated as fresh for `ACTUAL_SYNC_TTL_MS` (default 60s), so a burst of tool calls in one conversation still costs at most one sync. `0` syncs before every call; a negative value restores the previous behaviour for anyone who wants it.

A failed sync is logged rather than thrown — answering from slightly stale data beats failing the call outright when the server is briefly unreachable.

## Testing

Added `src/actual-api.test.ts` covering: no sync on first call, the budget is not re-downloaded, sync fires only past the TTL, `ACTUAL_SYNC_TTL_MS` is honoured for both `0` and negative values, and a failing sync doesn't break the call.

`npm run type-check`, `npm run lint` and `prettier --check` all pass.

Note: `src/tools/monthly-summary/report-generator.test.ts` has 2 failures on `main` before this change — they're pre-existing and unrelated.