### PR TITLE
fix: stop update-transaction payee_name from crashing the server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,18 @@ const safeStringify = (value: unknown): string => {
 const toErrorMessage = (value: unknown): string =>
   value instanceof Error ? `${value.name}: ${value.message}` : safeStringify(value);
 
+// Reason: a rejection or throw from anywhere in the process (e.g. an unawaited async
+// side-effect inside @actual-app/api, see s-stefanov/actual-mcp#150 and #95) otherwise
+// terminates the whole server. That kills every in-flight tool call and, over stdio,
+// disconnects the client; over HTTP it can leave sessions in a state that looks
+// connected but never responds. Log and keep serving instead of exiting.
+process.on('unhandledRejection', (reason) => {
+  console.error(`Unhandled rejection: ${toErrorMessage(reason)}`);
+});
+process.on('uncaughtException', (err) => {
+  console.error(`Uncaught exception: ${toErrorMessage(err)}`);
+});
+
 // ----------------------------
 // SERVER STARTUP
 // ----------------------------

--- a/src/tools/update-transaction/index.test.ts
+++ b/src/tools/update-transaction/index.test.ts
@@ -89,22 +89,6 @@ describe('update-transaction tool', () => {
       expect((result.content[0] as { text: string }).text).toContain('Updated fields: amount');
     });
 
-    it('should update with payee_name to create new payee', async () => {
-      vi.mocked(updateTransaction).mockResolvedValue(undefined);
-
-      const args = {
-        id: 'txn-123',
-        payee_name: 'New Grocery Store',
-      };
-
-      const result = await handler(args);
-
-      expect(updateTransaction).toHaveBeenCalledWith('txn-123', {
-        payee_name: 'New Grocery Store',
-      });
-      expect(result.isError).toBeUndefined();
-    });
-
     it('should update imported_payee field', async () => {
       vi.mocked(updateTransaction).mockResolvedValue(undefined);
 
@@ -348,6 +332,34 @@ describe('update-transaction tool', () => {
       const result = await handler(args);
 
       expect(result.isError).toBe(true);
+    });
+
+    it('should reject payee_name instead of forwarding it to the API', async () => {
+      const args = {
+        id: 'txn-123',
+        payee_name: 'New Grocery Store',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const result = await handler(args);
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('payee_name is not supported');
+      expect(updateTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should reject payee_name even when combined with other valid fields', async () => {
+      const args = {
+        id: 'txn-123',
+        amount: -5000,
+        payee_name: 'New Grocery Store',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+
+      const result = await handler(args);
+
+      expect(result.isError).toBe(true);
+      expect(updateTransaction).not.toHaveBeenCalled();
     });
   });
 

--- a/src/tools/update-transaction/index.ts
+++ b/src/tools/update-transaction/index.ts
@@ -1,6 +1,6 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { toJSONSchema } from 'zod';
-import { success, errorFromCatch } from '../../utils/response.js';
+import { error, success, errorFromCatch } from '../../utils/response.js';
 import { updateTransaction } from '../../actual-api.js';
 import { UpdateTransactionArgsSchema, type UpdateTransactionArgs, ToolInput } from '../../types.js';
 
@@ -13,6 +13,18 @@ export const schema = {
 
 export async function handler(args: UpdateTransactionArgs): Promise<CallToolResult> {
   try {
+    // Reason: payee_name is only resolved on the create/import path in @actual-app/api.
+    // On update it reaches an unguarded schema-conform step that throws asynchronously
+    // after the call already appears to succeed, crashing the whole server process
+    // (upstream https://github.com/s-stefanov/actual-mcp/issues/150). Reject it here
+    // with a clear alternative rather than silently dropping it or letting it crash.
+    if (args && typeof args === 'object' && 'payee_name' in args) {
+      return error(
+        'payee_name is not supported on update-transaction (it can crash the server). ' +
+          'Use create-payee to get or create a payee, then pass its id via the payee field instead.'
+      );
+    }
+
     const validatedArgs = UpdateTransactionArgsSchema.parse(args);
     const { id: transactionId, ...updateData } = validatedArgs;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,12 +89,6 @@ export const UpdateTransactionArgsSchema = z.object({
       'A currency amount as an integer representing the value without decimal places. For example, USD amount of $120.30 would be 12030'
     ),
   payee: z.string().optional().describe('An existing payee ID'),
-  payee_name: z
-    .string()
-    .optional()
-    .describe(
-      'If given, a payee will be created with this name. If this matches an already existing payee, that payee will be used.'
-    ),
   imported_payee: z
     .string()
     .optional()


### PR DESCRIPTION
Fixes #150

## Problem

Calling `update-transaction` with `payee_name` crashes the whole MCP server process (stdio disconnect, or on HTTP transport a session that silently stops responding). As diagnosed in #150 by @SturmB, the crash is an **unhandled rejection** thrown from an async side-effect deep in `@actual-app/api`'s update path (`conform` → `convertForUpdate` → `updateWithSchema`), which fires *after* the tool call has already returned success — so the response can claim success right before the process dies.

As @aSchimp noted in #150, `payee_name` resolution is only implemented on the create/import path (`addTransactions`) in `@actual-app/api`. `update-transaction`'s schema copy-pastes the field from create/import, but nothing on the update path actually resolves it — reproduced locally against a real Actual server: an `update-transaction` call with only `payee_name` set returns without throwing, but the transaction's `payee` field stays `null`. So today the field either silently no-ops or, depending on data, crashes the server — never does what its description promises.

## Fix

1. **Remove `payee_name` from `UpdateTransactionArgsSchema`.** Zod strips unrecognized keys, so it can no longer reach the crashing code path even from clients that still send it.
2. **Reject it explicitly in the handler** with a message pointing at the working alternative (`create-payee`, then pass the id via `payee`), so callers get a clear error instead of a silent no-op.
3. **Add process-level `unhandledRejection`/`uncaughtException` handlers** in `src/index.ts` as defense in depth (also raised in #150 and in #95) — logs to stderr and keeps serving, instead of one bad async rejection anywhere taking down a long-lived stdio/HTTP server.

## Test plan

- [x] `npm run test:unit` — 165/165 passing, including new/updated coverage for `update-transaction` rejecting `payee_name` (alone and combined with other valid fields)
- [x] `npm run lint` and `tsc -p tsconfig.build.json --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] Reproduced against a real Actual Budget server: confirmed `payee_name` on `update-transaction` leaves `payee` as `null` (silent no-op) rather than applying the rename, motivating the explicit rejection rather than just letting the schema silently strip it
- [x] Confirmed `get-payees` and `get-accounts` succeed independently and are unaffected — the "every payee-adjacent call fails" symptom some users see is collateral damage from a prior crash leaving the process/session unhealthy, not a `get-payees` bug itself