### PR TITLE
fix: bump @actual-app/api and @actual-app/core to 26.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.12.1",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/api": "26.8.1",
-        "@actual-app/core": "26.8.1",
+        "@actual-app/api": "26.9.0",
+        "@actual-app/core": "26.9.0",
         "@modelcontextprotocol/sdk": "1.27.1",
         "dotenv": "17.4.2",
         "express": "5.2.1",
@@ -39,12 +39,12 @@
       }
     },
     "node_modules/@actual-app/api": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.8.1.tgz",
-      "integrity": "sha512-FpOjTdbXEUlph1pElNANT/y2TwNn3vGbR/4SRRtic6x2kZIrrKZBCx4+X5/GobVNLPGJX66p6tVcki41nqpPZA==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/api/-/api-26.9.0.tgz",
+      "integrity": "sha512-jlDN/RWOqa5ToIM3k4ShpwMIh9sCMUqYYsS5IvAIykKscGkHdmJ+0YqcLhJrG3qOkWplArp8TNknJWASUMR5AA==",
       "license": "MIT",
       "dependencies": {
-        "@actual-app/core": "26.8.1",
+        "@actual-app/core": "26.9.0",
         "@actual-app/crdt": "3.1.1",
         "better-sqlite3": "^12.11.1",
         "compare-versions": "^6.1.1",
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@actual-app/core": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.8.1.tgz",
-      "integrity": "sha512-1uvhHqZ4QeBeOkEzLr+OAvRKQWSZr1E+oO32V2v4HgqwUF1MUkHtUZqEaf7WQswaF8hNNTI0GeL2goVbTJu6xg==",
+      "version": "26.9.0",
+      "resolved": "https://registry.npmjs.org/@actual-app/core/-/core-26.9.0.tgz",
+      "integrity": "sha512-Nn6rxZQRoCYIaHtc0ZSAinA7RgYV24QuHW+XE3aJWBu9qcttjSUIBMQrBo+W960C++FcityvkIi3Yj1XIUGy+g==",
       "license": "ISC",
       "dependencies": {
         "@jlongster/sql.js": "^1.6.7",
@@ -2356,9 +2356,9 @@
       "license": "MIT"
     },
     "node_modules/csv-stringify": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.1.tgz",
-      "integrity": "sha512-tZ6X6TKQyQgCo5OptXcyAbfN1pwmoxEqELPQ7KFazNErx7kiVsDK8o+VYRXhfMl4N9vvOOLXuioquR2MeP847A==",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.8.3.tgz",
+      "integrity": "sha512-gIeSCvq5F4VtXV3naV3VAewLhBkiZBz+PPhTOA8H3Y8h/ELa+R1ml0GZck/4/Nzo9ep2lvOluilJ6MJlbZsKMA==",
       "license": "MIT"
     },
     "node_modules/date-fns": {
@@ -2525,14 +2525,15 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
-      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
       "license": "MIT",
       "workspaces": [
         "docs",
         "benchmarks",
-        "tests/types"
+        "tests/types",
+        "tests/browser-compat"
       ]
     },
     "node_modules/esbuild": {
@@ -3327,9 +3328,9 @@
       }
     },
     "node_modules/hyperformula": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.3.0.tgz",
-      "integrity": "sha512-Mkc7AxP9WQDM4xHo1/XpAwzcpMLkwMand4HO9rfRzP502TBzoR1Z96zoCzRrwXodLSVyh+MD7FvzRVALDxmRFQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/hyperformula/-/hyperformula-3.4.0.tgz",
+      "integrity": "sha512-w1N11JWfdHedHpNoSgYBd3Mz7e1yr1BEQ+g4GFJbLv+qlYVXyC4I8xy1mSwj13FhcoDBGNU5yxPCdXB6vwaYaA==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "chevrotain": "^6.5.0",
@@ -4126,9 +4127,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@actual-app/api": "26.8.1",
-    "@actual-app/core": "26.8.1",
+    "@actual-app/api": "26.9.0",
+    "@actual-app/core": "26.9.0",
     "@modelcontextprotocol/sdk": "1.27.1",
     "dotenv": "17.4.2",
     "express": "5.2.1",


### PR DESCRIPTION
Follow-up to #191.

Server 26.9.0 ships migrations that 26.8.1 loot-core can't read, so budgets fail to open with "This budget could not be loaded because it uses a newer database schema than this version of Actual supports."

Verified against a self-hosted 26.9.0 server: budget opens and tool calls return data. Build and tests pass.