### PR TITLE
feat: add budget endpoints (getBudgetMonths, getBudgetMonth, setBudgetAmount, setBudgetCarryover, holdBudgetForNextMonth, resetBudgetHold)

### DIFF
--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -330,3 +330,70 @@ export async function runBankSync(accountId?: string): Promise<void> {
   // API expects { accountId } object or undefined for all accounts
   return api.runBankSync(accountId ? { accountId } : undefined);
 }
+
+// ----------------------------
+// BUDGETS
+// ----------------------------
+
+/**
+ * Get all budget months (ensures API is initialized)
+ */
+export async function getBudgetMonths(): Promise<string[]> {
+  await initActualApi();
+  return api.getBudgetMonths();
+}
+
+/**
+ * Get budget data for a specific month (ensures API is initialized)
+ *
+ * @param month - Month in YYYY-MM format
+ */
+export async function getBudgetMonth(month: string): Promise<unknown> {
+  await initActualApi();
+  return api.getBudgetMonth(month);
+}
+
+/**
+ * Set the budgeted amount for a category in a given month (ensures API is initialized)
+ *
+ * @param month - Month in YYYY-MM format
+ * @param categoryId - ID of the category
+ * @param value - Amount in integer cents (e.g. 12030 = $120.30)
+ */
+export async function setBudgetAmount(month: string, categoryId: string, value: number): Promise<void> {
+  await initActualApi();
+  return api.setBudgetAmount(month, categoryId, value);
+}
+
+/**
+ * Enable or disable carryover for a category in a given month (ensures API is initialized)
+ *
+ * @param month - Month in YYYY-MM format
+ * @param categoryId - ID of the category
+ * @param flag - true to enable carryover, false to disable
+ */
+export async function setBudgetCarryover(month: string, categoryId: string, flag: boolean): Promise<void> {
+  await initActualApi();
+  return api.setBudgetCarryover(month, categoryId, flag);
+}
+
+/**
+ * Hold budget funds for the next month (ensures API is initialized)
+ *
+ * @param month - Month in YYYY-MM format
+ * @param value - Amount in integer cents to hold
+ */
+export async function holdBudgetForNextMonth(month: string, value: number): Promise<boolean> {
+  await initActualApi();
+  return api.holdBudgetForNextMonth(month, value);
+}
+
+/**
+ * Reset any held budget amounts for a month (ensures API is initialized)
+ *
+ * @param month - Month in YYYY-MM format
+ */
+export async function resetBudgetHold(month: string): Promise<void> {
+  await initActualApi();
+  return api.resetBudgetHold(month);
+}

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -29,8 +29,10 @@ export const setupResources = (server: Server): void => {
         })),
       };
     } catch (error) {
+      // Reason: re-throwing a non-Error APIError object causes an unhandled rejection crash in Node ≥15.
+      // Return an empty list so the MCP server stays alive when the budget isn't loaded yet.
       console.error('Error listing resources:', error);
-      throw error;
+      return { resources: [] };
     } finally {
       await shutdownActualApi();
     }

--- a/src/tools/budgets/get-budget-month/index.test.ts
+++ b/src/tools/budgets/get-budget-month/index.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  getBudgetMonth: vi.fn(),
+}));
+
+import { getBudgetMonth } from '../../../actual-api.js';
+
+const mockBudgetMonth = {
+  month: '2025-01',
+  incomeAvailable: 500000,
+  lastMonthOverspent: 0,
+  forNextMonth: 0,
+  totalBudgeted: -450000,
+  toBudget: 50000,
+  categoryGroups: [
+    {
+      id: 'group-1',
+      name: 'Essentials',
+      budgeted: 200000,
+      spent: -150000,
+      balance: 50000,
+      categories: [
+        { id: 'cat-1', name: 'Groceries', budgeted: 200000, spent: -150000, balance: 50000, carryover: false },
+      ],
+    },
+  ],
+};
+
+describe('get-budget-month tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('get-budget-month');
+      expect(schema.description).toContain('budget data');
+    });
+
+    it('should have inputSchema with required month field', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should return budget data for given month', async () => {
+      vi.mocked(getBudgetMonth).mockResolvedValue(mockBudgetMonth);
+
+      const result = await handler({ month: '2025-01' });
+
+      expect(getBudgetMonth).toHaveBeenCalledWith('2025-01');
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Groceries');
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should return error when month is missing', async () => {
+      const result = await handler({});
+
+      expect(result.isError).toBe(true);
+      expect(getBudgetMonth).not.toHaveBeenCalled();
+    });
+
+    it('should return error when month is not a string', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await handler({ month: 202501 } as any);
+
+      expect(result.isError).toBe(true);
+      expect(getBudgetMonth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(getBudgetMonth).mockRejectedValue(new Error('Month not found'));
+
+      const result = await handler({ month: '2025-01' });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Month not found');
+    });
+  });
+});

--- a/src/tools/budgets/get-budget-month/index.ts
+++ b/src/tools/budgets/get-budget-month/index.ts
@@ -1,0 +1,34 @@
+// ----------------------------
+// GET BUDGET MONTH TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { getBudgetMonth } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const GetBudgetMonthArgsSchema = z.object({
+  month: z.string().describe('Month in YYYY-MM format (e.g. "2025-01")'),
+});
+
+export const schema = {
+  name: 'get-budget-month',
+  description:
+    'Retrieve budget data for a specific month, including budgeted amounts, spending, and balances per category.',
+  inputSchema: toJSONSchema(GetBudgetMonthArgsSchema) as ToolInput,
+};
+
+export async function handler(
+  args: Record<string, unknown>
+): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const parsed = GetBudgetMonthArgsSchema.safeParse(args);
+    if (!parsed.success) {
+      return errorFromCatch(`Invalid arguments: ${parsed.error.message}`);
+    }
+    const data = await getBudgetMonth(parsed.data.month);
+    return successWithJson(data);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/budgets/get-budget-months/index.test.ts
+++ b/src/tools/budgets/get-budget-months/index.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  getBudgetMonths: vi.fn(),
+}));
+
+import { getBudgetMonths } from '../../../actual-api.js';
+
+describe('get-budget-months tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('get-budget-months');
+      expect(schema.description).toContain('budget months');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should return list of budget months', async () => {
+      const months = ['2025-01', '2025-02', '2025-03'];
+      vi.mocked(getBudgetMonths).mockResolvedValue(months);
+
+      const result = await handler();
+
+      expect(getBudgetMonths).toHaveBeenCalledOnce();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('2025-01');
+    });
+
+    it('should return empty array when no months exist', async () => {
+      vi.mocked(getBudgetMonths).mockResolvedValue([]);
+
+      const result = await handler();
+
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('[]');
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(getBudgetMonths).mockRejectedValue(new Error('Connection failed'));
+
+      const result = await handler();
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Connection failed');
+    });
+  });
+});

--- a/src/tools/budgets/get-budget-months/index.ts
+++ b/src/tools/budgets/get-budget-months/index.ts
@@ -1,0 +1,25 @@
+// ----------------------------
+// GET BUDGET MONTHS TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { getBudgetMonths } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const GetBudgetMonthsArgsSchema = z.object({});
+
+export const schema = {
+  name: 'get-budget-months',
+  description: 'Retrieve a list of all available budget months in YYYY-MM format.',
+  inputSchema: toJSONSchema(GetBudgetMonthsArgsSchema) as ToolInput,
+};
+
+export async function handler(): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const months = await getBudgetMonths();
+    return successWithJson(months);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/budgets/hold-budget-for-next-month/index.test.ts
+++ b/src/tools/budgets/hold-budget-for-next-month/index.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  holdBudgetForNextMonth: vi.fn(),
+}));
+
+import { holdBudgetForNextMonth } from '../../../actual-api.js';
+
+describe('hold-budget-for-next-month tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('hold-budget-for-next-month');
+      expect(schema.description).toContain('budget funds');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should hold budget and return success message', async () => {
+      vi.mocked(holdBudgetForNextMonth).mockResolvedValue(true);
+
+      const result = await handler({ month: '2025-01', value: 10000 });
+
+      expect(holdBudgetForNextMonth).toHaveBeenCalledWith('2025-01', 10000);
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('10000');
+    });
+
+    it('should handle holding zero cents (no-op hold)', async () => {
+      vi.mocked(holdBudgetForNextMonth).mockResolvedValue(true);
+
+      const result = await handler({ month: '2025-03', value: 0 });
+
+      expect(holdBudgetForNextMonth).toHaveBeenCalledWith('2025-03', 0);
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should return error when value is missing', async () => {
+      const result = await handler({ month: '2025-01' });
+
+      expect(result.isError).toBe(true);
+      expect(holdBudgetForNextMonth).not.toHaveBeenCalled();
+    });
+
+    it('should return error when value is a decimal', async () => {
+      const result = await handler({ month: '2025-01', value: 99.99 });
+
+      expect(result.isError).toBe(true);
+      expect(holdBudgetForNextMonth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(holdBudgetForNextMonth).mockRejectedValue(new Error('Insufficient funds'));
+
+      const result = await handler({ month: '2025-01', value: 99999999 });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Insufficient funds');
+    });
+  });
+});

--- a/src/tools/budgets/hold-budget-for-next-month/index.ts
+++ b/src/tools/budgets/hold-budget-for-next-month/index.ts
@@ -1,0 +1,36 @@
+// ----------------------------
+// HOLD BUDGET FOR NEXT MONTH TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { holdBudgetForNextMonth } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const HoldBudgetForNextMonthArgsSchema = z.object({
+  month: z.string().describe('Month in YYYY-MM format (e.g. "2025-01")'),
+  value: z.number().int().describe('Amount in integer cents to hold for the next month (e.g. 5000 = $50.00)'),
+});
+
+export const schema = {
+  name: 'hold-budget-for-next-month',
+  description:
+    'Reserve budget funds from the current month to be used in the following month. Value must be in integer cents.',
+  inputSchema: toJSONSchema(HoldBudgetForNextMonthArgsSchema) as ToolInput,
+};
+
+export async function handler(
+  args: Record<string, unknown>
+): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const parsed = HoldBudgetForNextMonthArgsSchema.safeParse(args);
+    if (!parsed.success) {
+      return errorFromCatch(`Invalid arguments: ${parsed.error.message}`);
+    }
+    const { month, value } = parsed.data;
+    await holdBudgetForNextMonth(month, value);
+    return successWithJson(`Successfully held ${value} cents for next month from ${month}`);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/budgets/reset-budget-hold/index.test.ts
+++ b/src/tools/budgets/reset-budget-hold/index.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  resetBudgetHold: vi.fn(),
+}));
+
+import { resetBudgetHold } from '../../../actual-api.js';
+
+describe('reset-budget-hold tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('reset-budget-hold');
+      expect(schema.description).toContain('held budget');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should reset budget hold and return success message', async () => {
+      vi.mocked(resetBudgetHold).mockResolvedValue(undefined);
+
+      const result = await handler({ month: '2025-01' });
+
+      expect(resetBudgetHold).toHaveBeenCalledWith('2025-01');
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('2025-01');
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should return error when month is missing', async () => {
+      const result = await handler({});
+
+      expect(result.isError).toBe(true);
+      expect(resetBudgetHold).not.toHaveBeenCalled();
+    });
+
+    it('should return error when month is not a string', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await handler({ month: 202501 } as any);
+
+      expect(result.isError).toBe(true);
+      expect(resetBudgetHold).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(resetBudgetHold).mockRejectedValue(new Error('Reset failed'));
+
+      const result = await handler({ month: '2025-01' });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Reset failed');
+    });
+  });
+});

--- a/src/tools/budgets/reset-budget-hold/index.ts
+++ b/src/tools/budgets/reset-budget-hold/index.ts
@@ -1,0 +1,33 @@
+// ----------------------------
+// RESET BUDGET HOLD TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { resetBudgetHold } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const ResetBudgetHoldArgsSchema = z.object({
+  month: z.string().describe('Month in YYYY-MM format (e.g. "2025-01")'),
+});
+
+export const schema = {
+  name: 'reset-budget-hold',
+  description: 'Clear any held budget amounts for a specified month, releasing them back to the available balance.',
+  inputSchema: toJSONSchema(ResetBudgetHoldArgsSchema) as ToolInput,
+};
+
+export async function handler(
+  args: Record<string, unknown>
+): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const parsed = ResetBudgetHoldArgsSchema.safeParse(args);
+    if (!parsed.success) {
+      return errorFromCatch(`Invalid arguments: ${parsed.error.message}`);
+    }
+    await resetBudgetHold(parsed.data.month);
+    return successWithJson(`Successfully reset budget hold for ${parsed.data.month}`);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/budgets/set-budget-amount/index.test.ts
+++ b/src/tools/budgets/set-budget-amount/index.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  setBudgetAmount: vi.fn(),
+}));
+
+import { setBudgetAmount } from '../../../actual-api.js';
+
+describe('set-budget-amount tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('set-budget-amount');
+      expect(schema.description).toContain('budgeted amount');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should set budget amount and return success message', async () => {
+      vi.mocked(setBudgetAmount).mockResolvedValue(undefined);
+
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123', value: 50000 });
+
+      expect(setBudgetAmount).toHaveBeenCalledWith('2025-01', 'cat-123', 50000);
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('cat-123');
+    });
+
+    it('should handle zero value (clearing a budget)', async () => {
+      vi.mocked(setBudgetAmount).mockResolvedValue(undefined);
+
+      const result = await handler({ month: '2025-06', categoryId: 'cat-456', value: 0 });
+
+      expect(setBudgetAmount).toHaveBeenCalledWith('2025-06', 'cat-456', 0);
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should return error when month is missing', async () => {
+      const result = await handler({ categoryId: 'cat-123', value: 5000 });
+
+      expect(result.isError).toBe(true);
+      expect(setBudgetAmount).not.toHaveBeenCalled();
+    });
+
+    it('should return error when value is not an integer', async () => {
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123', value: 50.5 });
+
+      expect(result.isError).toBe(true);
+      expect(setBudgetAmount).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(setBudgetAmount).mockRejectedValue(new Error('Category not found'));
+
+      const result = await handler({ month: '2025-01', categoryId: 'cat-999', value: 10000 });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Category not found');
+    });
+  });
+});

--- a/src/tools/budgets/set-budget-amount/index.ts
+++ b/src/tools/budgets/set-budget-amount/index.ts
@@ -1,0 +1,37 @@
+// ----------------------------
+// SET BUDGET AMOUNT TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { setBudgetAmount } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const SetBudgetAmountArgsSchema = z.object({
+  month: z.string().describe('Month in YYYY-MM format (e.g. "2025-01")'),
+  categoryId: z.string().describe('ID of the category to budget'),
+  value: z.number().int().describe('Budgeted amount in integer cents (e.g. 12030 = $120.30)'),
+});
+
+export const schema = {
+  name: 'set-budget-amount',
+  description:
+    'Set the budgeted amount for a category in a given month. Value must be in integer cents (e.g. 12030 = $120.30).',
+  inputSchema: toJSONSchema(SetBudgetAmountArgsSchema) as ToolInput,
+};
+
+export async function handler(
+  args: Record<string, unknown>
+): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const parsed = SetBudgetAmountArgsSchema.safeParse(args);
+    if (!parsed.success) {
+      return errorFromCatch(`Invalid arguments: ${parsed.error.message}`);
+    }
+    const { month, categoryId, value } = parsed.data;
+    await setBudgetAmount(month, categoryId, value);
+    return successWithJson(`Successfully set budget amount for category ${categoryId} in ${month}`);
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/budgets/set-budget-carryover/index.test.ts
+++ b/src/tools/budgets/set-budget-carryover/index.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler, schema } from './index.js';
+
+vi.mock('../../../actual-api.js', () => ({
+  setBudgetCarryover: vi.fn(),
+}));
+
+import { setBudgetCarryover } from '../../../actual-api.js';
+
+describe('set-budget-carryover tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('schema', () => {
+    it('should have correct name and description', () => {
+      expect(schema.name).toBe('set-budget-carryover');
+      expect(schema.description).toContain('carryover');
+    });
+
+    it('should have inputSchema defined', () => {
+      expect(schema.inputSchema).toBeDefined();
+      expect(schema.inputSchema.type).toBe('object');
+    });
+  });
+
+  describe('handler - happy path', () => {
+    it('should enable carryover and return success message', async () => {
+      vi.mocked(setBudgetCarryover).mockResolvedValue(undefined);
+
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123', flag: true });
+
+      expect(setBudgetCarryover).toHaveBeenCalledWith('2025-01', 'cat-123', true);
+      expect(result.isError).toBeFalsy();
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('enabled');
+    });
+
+    it('should disable carryover and indicate so in the message', async () => {
+      vi.mocked(setBudgetCarryover).mockResolvedValue(undefined);
+
+      const result = await handler({ month: '2025-02', categoryId: 'cat-456', flag: false });
+
+      expect(setBudgetCarryover).toHaveBeenCalledWith('2025-02', 'cat-456', false);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('disabled');
+    });
+  });
+
+  describe('handler - validation errors', () => {
+    it('should return error when flag is missing', async () => {
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123' });
+
+      expect(result.isError).toBe(true);
+      expect(setBudgetCarryover).not.toHaveBeenCalled();
+    });
+
+    it('should return error when flag is not a boolean', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123', flag: 'yes' } as any);
+
+      expect(result.isError).toBe(true);
+      expect(setBudgetCarryover).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler - API errors', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(setBudgetCarryover).mockRejectedValue(new Error('Database error'));
+
+      const result = await handler({ month: '2025-01', categoryId: 'cat-123', flag: true });
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('Database error');
+    });
+  });
+});

--- a/src/tools/budgets/set-budget-carryover/index.ts
+++ b/src/tools/budgets/set-budget-carryover/index.ts
@@ -1,0 +1,38 @@
+// ----------------------------
+// SET BUDGET CARRYOVER TOOL
+// ----------------------------
+
+import { z, toJSONSchema } from 'zod';
+import { successWithJson, errorFromCatch } from '../../../utils/response.js';
+import { setBudgetCarryover } from '../../../actual-api.js';
+import { type ToolInput } from '../../../types.js';
+
+const SetBudgetCarryoverArgsSchema = z.object({
+  month: z.string().describe('Month in YYYY-MM format (e.g. "2025-01")'),
+  categoryId: z.string().describe('ID of the category'),
+  flag: z.boolean().describe('true to enable carryover of unspent funds, false to disable'),
+});
+
+export const schema = {
+  name: 'set-budget-carryover',
+  description: 'Enable or disable carryover of unspent funds for a category into the next month.',
+  inputSchema: toJSONSchema(SetBudgetCarryoverArgsSchema) as ToolInput,
+};
+
+export async function handler(
+  args: Record<string, unknown>
+): Promise<ReturnType<typeof successWithJson> | ReturnType<typeof errorFromCatch>> {
+  try {
+    const parsed = SetBudgetCarryoverArgsSchema.safeParse(args);
+    if (!parsed.success) {
+      return errorFromCatch(`Invalid arguments: ${parsed.error.message}`);
+    }
+    const { month, categoryId, flag } = parsed.data;
+    await setBudgetCarryover(month, categoryId, flag);
+    return successWithJson(
+      `Successfully ${flag ? 'enabled' : 'disabled'} carryover for category ${categoryId} in ${month}`
+    );
+  } catch (err) {
+    return errorFromCatch(err);
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -29,6 +29,12 @@ import * as updateRule from './rules/update-rule/index.js';
 import * as spendingByCategory from './spending-by-category/index.js';
 import * as deleteTransaction from './delete-transaction/index.js';
 import * as updateTransaction from './update-transaction/index.js';
+import * as getBudgetMonths from './budgets/get-budget-months/index.js';
+import * as getBudgetMonth from './budgets/get-budget-month/index.js';
+import * as setBudgetAmount from './budgets/set-budget-amount/index.js';
+import * as setBudgetCarryover from './budgets/set-budget-carryover/index.js';
+import * as holdBudgetForNextMonth from './budgets/hold-budget-for-next-month/index.js';
+import * as resetBudgetHold from './budgets/reset-budget-hold/index.js';
 import * as createTransaction from './create-transaction/index.js';
 import * as importTransactions from './import-transactions/index.js';
 import * as runBankSync from './run-bank-sync/index.js';
@@ -42,6 +48,8 @@ const readTools = [
   getGroupedCategories,
   getPayees,
   getRules,
+  getBudgetMonths,
+  getBudgetMonth,
 ];
 
 const writeTools = [
@@ -62,6 +70,10 @@ const writeTools = [
   createTransaction,
   importTransactions,
   runBankSync,
+  setBudgetAmount,
+  setBudgetCarryover,
+  holdBudgetForNextMonth,
+  resetBudgetHold,
 ];
 
 export const setupTools = (server: Server, enableWrite: boolean): void => {

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -75,7 +75,21 @@ export function error(message: string): CallToolResult {
  * @returns An error response object
  */
 export function errorFromCatch(err: unknown): CallToolResult {
-  const message = err instanceof Error ? err.message : String(err);
+  let message: string;
+  if (err instanceof Error) {
+    message = err.message;
+  } else if (
+    typeof err === 'object' &&
+    err !== null &&
+    'message' in err &&
+    typeof (err as Record<string, unknown>).message === 'string'
+  ) {
+    // Reason: @actual-app/api throws structured objects like { type: 'APIError', message: '...' }
+    // rather than Error instances. Extract the message field so errors are human-readable.
+    message = (err as Record<string, unknown>).message as string;
+  } else {
+    message = String(err);
+  }
   return error(message);
 }
 


### PR DESCRIPTION
Closes #163

Rebuilds the still-relevant subset of #163 onto current `main` (`@actual-app/api` 26.8.1) since a force-push to the original branch was blocked by OAuth `workflow` scope restrictions on `kidpollo/actual-mcp`.

Original work and authorship credit: **@kidpollo** (Francisco Viramontes). The squashed commit here is authored by him with a `Co-Authored-By: Claude` trailer for the rebuild work.

## What's kept
- Six budget MCP tools (2 read, 4 write): `getBudgetMonths`, `getBudgetMonth`, `setBudgetAmount`, `setBudgetCarryover`, `holdBudgetForNextMonth`, `resetBudgetHold`, with zod validation and 38 unit tests.
- `errorFromCatch` now extracts `.message` from structured `{ type, message }` API errors instead of serialising them as `[object Object]`.
- `ListResources` returns an empty list instead of re-throwing a non-Error object (avoids an unhandled-rejection crash on Node ≥15 when the budget isn't loaded yet).

## What's dropped from the original #163
- The `@actual-app/api`/`@actual-app/core` 26.4.0 downgrade (kept at 26.8.1).
- `src/stubs/actual-core.d.ts` and the `tsconfig.json` `paths` entry it required.
- The duplicate `unhandledRejection` guard (already on `main` via #204).

Independently verified against a live server by @ryanmac8 on the original PR.

## Test plan
- [x] `npm run type-check`
- [x] `npm run test` (203/203 passing, including the 38 new budget tests)
- [x] `npm run build`
- [x] `npm run lint`