### PR TITLE
fix: support transfers originating from a split's subtransaction

### DIFF
--- a/src/core/data/resolve-transfer-payee.test.ts
+++ b/src/core/data/resolve-transfer-payee.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveTransferPayee } from './resolve-transfer-payee.js';
+import * as actualApi from '../../actual-api.js';
+
+vi.mock('../../actual-api.js', () => ({
+  getPayees: vi.fn(),
+}));
+
+describe('resolveTransferPayee', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the id of the payee whose transfer_acct matches the destination account', async () => {
+    vi.mocked(actualApi.getPayees).mockResolvedValue([
+      { id: 'payee-checking', name: 'Transfer: Checking', transfer_acct: 'checking-account-id' },
+      { id: 'payee-savings', name: 'Transfer: Savings', transfer_acct: 'savings-account-id' },
+    ]);
+
+    const result = await resolveTransferPayee('savings-account-id');
+
+    expect(result).toBe('payee-savings');
+  });
+
+  it('returns null when no payee has that transfer_acct', async () => {
+    vi.mocked(actualApi.getPayees).mockResolvedValue([
+      { id: 'payee-checking', name: 'Transfer: Checking', transfer_acct: 'checking-account-id' },
+    ]);
+
+    const result = await resolveTransferPayee('nonexistent-account-id');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when getPayees resolves an empty list', async () => {
+    vi.mocked(actualApi.getPayees).mockResolvedValue([]);
+
+    const result = await resolveTransferPayee('any-account-id');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/core/data/resolve-transfer-payee.ts
+++ b/src/core/data/resolve-transfer-payee.ts
@@ -1,0 +1,14 @@
+import { getPayees } from '../../actual-api.js';
+
+/**
+ * Resolve the transfer payee ID for a given destination account.
+ * Each account in Actual has a corresponding payee with transfer_acct set;
+ * assigning that payee to a transaction (or a split's subtransaction) turns
+ * it into a transfer leg — the counterpart transaction is created automatically
+ * when the write is done with runTransfers enabled (the default).
+ */
+export async function resolveTransferPayee(destinationAccountId: string): Promise<string | null> {
+  const payees = await getPayees();
+  const transferPayee = payees.find((p) => p.transfer_acct === destinationAccountId);
+  return transferPayee?.id ?? null;
+}

--- a/src/tools/create-transaction/index.test.ts
+++ b/src/tools/create-transaction/index.test.ts
@@ -196,6 +196,56 @@ describe('create-transaction tool', () => {
       expect(textContent(result.content[0])).toContain('No transfer payee found');
       expect(actualApi.createTransaction).not.toHaveBeenCalled();
     });
+
+    it('should resolve transfer payee for a subtransaction of a split', async () => {
+      const mockTransactionId = 'split-transfer-txn-1';
+      vi.mocked(actualApi.getPayees).mockResolvedValue([
+        { id: 'payee-savings', name: 'Transfer: Savings', transfer_acct: 'savings-account-id' },
+      ]);
+      vi.mocked(actualApi.createTransaction).mockResolvedValue(mockTransactionId);
+
+      const args: CreateTransactionArgs = {
+        account: 'checking-account-id',
+        date: '2025-12-18',
+        amount: -10000,
+        subtransactions: [
+          { amount: -6000, category: 'cat-groceries' },
+          { amount: -4000, transfer_account_id: 'savings-account-id' },
+        ],
+      };
+
+      const result = await handler(args);
+
+      expect(actualApi.getPayees).toHaveBeenCalled();
+      expect(actualApi.createTransaction).toHaveBeenCalledWith('checking-account-id', {
+        date: '2025-12-18',
+        amount: -10000,
+        subtransactions: [
+          { amount: -6000, category: 'cat-groceries' },
+          { amount: -4000, payee: 'payee-savings' },
+        ],
+      });
+      expect(result.isError).toBeUndefined();
+      expect(textContent(result.content[0])).toContain('transfer');
+      expect(textContent(result.content[0])).toContain('counterpart');
+    });
+
+    it('should return error when a subtransaction transfer payee is not found', async () => {
+      vi.mocked(actualApi.getPayees).mockResolvedValue([]);
+
+      const args: CreateTransactionArgs = {
+        account: 'checking-account-id',
+        date: '2025-12-18',
+        amount: -10000,
+        subtransactions: [{ amount: -10000, transfer_account_id: 'nonexistent-account-id' }],
+      };
+
+      const result = await handler(args);
+
+      expect(result.isError).toBe(true);
+      expect(textContent(result.content[0])).toContain('No transfer payee found');
+      expect(actualApi.createTransaction).not.toHaveBeenCalled();
+    });
   });
 
   describe('handler - validation errors', () => {

--- a/src/tools/create-transaction/index.ts
+++ b/src/tools/create-transaction/index.ts
@@ -5,25 +5,17 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { toJSONSchema } from 'zod';
 import { successWithJson, errorFromCatch, error } from '../../utils/response.js';
-import { createTransaction, getPayees } from '../../actual-api.js';
+import { createTransaction } from '../../actual-api.js';
+import { resolveTransferPayee } from '../../core/data/resolve-transfer-payee.js';
 import { CreateTransactionArgsSchema, type CreateTransactionArgs, ToolInput } from '../../types.js';
 
 export const schema = {
   name: 'create-transaction',
   description:
-    'Create a new transaction. Use this to add transactions to accounts. Supports transfers between accounts by specifying transfer_account_id.',
+    'Create a new transaction. Use this to add transactions to accounts. Supports transfers between accounts by ' +
+    'specifying transfer_account_id, including transfers originating from a single subtransaction of a split.',
   inputSchema: toJSONSchema(CreateTransactionArgsSchema) as ToolInput,
 };
-
-/**
- * Resolve the transfer payee ID for a given destination account.
- * Each account in Actual has a corresponding payee with transfer_acct set.
- */
-async function resolveTransferPayee(destinationAccountId: string): Promise<string | null> {
-  const payees = await getPayees();
-  const transferPayee = payees.find((p) => p.transfer_acct === destinationAccountId);
-  return transferPayee?.id ?? null;
-}
 
 export async function handler(args: CreateTransactionArgs): Promise<CallToolResult> {
   try {
@@ -44,11 +36,32 @@ export async function handler(args: CreateTransactionArgs): Promise<CallToolResu
       transactionData.payee = transferPayeeId;
     }
 
+    // Reason: A subtransaction can itself be a transfer leg (e.g. a split where part of the
+    // amount is a purchase and part is a transfer to savings). Resolve each subtransaction's
+    // transfer_account_id into the corresponding transfer payee before sending to the API.
+    let hasSubtransactionTransfer = false;
+    if (transactionData.subtransactions) {
+      for (const sub of transactionData.subtransactions) {
+        if (sub.transfer_account_id) {
+          const subTransferPayeeId = await resolveTransferPayee(sub.transfer_account_id);
+          if (!subTransferPayeeId) {
+            return error(
+              `No transfer payee found for account ${sub.transfer_account_id}. Ensure the destination account exists.`
+            );
+          }
+          sub.payee = subTransferPayeeId;
+          hasSubtransactionTransfer = true;
+        }
+        delete sub.transfer_account_id;
+      }
+    }
+
     const id: string = await createTransaction(accountId, transactionData);
 
-    const message = transfer_account_id
-      ? `Successfully created transfer transaction ${id} (counterpart created in destination account)`
-      : `Successfully created transaction ${id}`;
+    const message =
+      transfer_account_id || hasSubtransactionTransfer
+        ? `Successfully created transfer transaction ${id} (counterpart created in destination account)`
+        : `Successfully created transaction ${id}`;
 
     return successWithJson(message);
   } catch (err) {

--- a/src/tools/import-transactions/index.test.ts
+++ b/src/tools/import-transactions/index.test.ts
@@ -11,6 +11,7 @@ import { textContent } from '../../utils/response.js';
 // Mock the actual-api module
 vi.mock('../../actual-api.js', () => ({
   importTransactions: vi.fn(),
+  getPayees: vi.fn(),
 }));
 
 // Mock @actual-app/api utils so amountToInteger works without a real API connection
@@ -138,6 +139,74 @@ describe('import-transactions tool', () => {
 
       expect(result.isError).toBeUndefined();
       expect(textContent(result.content[0])).toContain('Invalid date on row 1');
+    });
+  });
+
+  describe('handler - transfer cases', () => {
+    it('should resolve transfer payee for a subtransaction of a split', async () => {
+      vi.mocked(actualApi.getPayees).mockResolvedValue([
+        { id: 'payee-savings', name: 'Transfer: Savings', transfer_acct: 'savings-account-id' },
+      ]);
+      vi.mocked(actualApi.importTransactions).mockResolvedValue({
+        added: ['tx-parent', 'tx-child-1', 'tx-child-2'],
+        updated: [],
+        errors: [],
+      });
+
+      const args: ImportTransactionsArgs = {
+        accountId: 'account-123',
+        transactions: [
+          {
+            date: '2025-01-01',
+            amount: -100,
+            subtransactions: [
+              { amount: -60, category: 'cat-groceries' },
+              { amount: -40, transfer_account_id: 'savings-account-id' },
+            ],
+          },
+        ],
+      };
+
+      const result = await handler(args);
+
+      expect(actualApi.getPayees).toHaveBeenCalled();
+      expect(actualApi.importTransactions).toHaveBeenCalledWith(
+        'account-123',
+        [
+          {
+            date: '2025-01-01',
+            amount: -10000,
+            account: 'account-123',
+            subtransactions: [
+              { amount: -6000, category: 'cat-groceries' },
+              { amount: -4000, payee: 'payee-savings' },
+            ],
+          },
+        ],
+        { defaultCleared: undefined, dryRun: undefined }
+      );
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should return error when a subtransaction transfer payee is not found', async () => {
+      vi.mocked(actualApi.getPayees).mockResolvedValue([]);
+
+      const args: ImportTransactionsArgs = {
+        accountId: 'account-123',
+        transactions: [
+          {
+            date: '2025-01-01',
+            amount: -100,
+            subtransactions: [{ amount: -100, transfer_account_id: 'nonexistent-account-id' }],
+          },
+        ],
+      };
+
+      const result = await handler(args);
+
+      expect(result.isError).toBe(true);
+      expect(textContent(result.content[0])).toContain('No transfer payee found');
+      expect(actualApi.importTransactions).not.toHaveBeenCalled();
     });
   });
 

--- a/src/tools/import-transactions/index.ts
+++ b/src/tools/import-transactions/index.ts
@@ -5,8 +5,9 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { utils } from '@actual-app/api';
 import { toJSONSchema } from 'zod';
-import { success, errorFromCatch } from '../../utils/response.js';
+import { success, error, errorFromCatch } from '../../utils/response.js';
 import { importTransactions } from '../../actual-api.js';
+import { resolveTransferPayee } from '../../core/data/resolve-transfer-payee.js';
 import { ImportTransactionsArgsSchema, type ImportTransactionsArgs, ToolInput } from '../../types.js';
 
 export const schema = {
@@ -14,13 +15,33 @@ export const schema = {
   description:
     'Import a list of transactions into an account using reconciliation logic. ' +
     'Deduplicates via imported_id to prevent duplicates on repeated imports. ' +
-    'Supports dry-run mode to preview changes without persisting them.',
+    'Supports dry-run mode to preview changes without persisting them. ' +
+    'Supports transfers, including transfers originating from a single subtransaction of a split, via transfer_account_id.',
   inputSchema: toJSONSchema(ImportTransactionsArgsSchema) as ToolInput,
 };
 
 export async function handler(args: ImportTransactionsArgs): Promise<CallToolResult> {
   try {
     const { accountId, transactions, defaultCleared, dryRun } = ImportTransactionsArgsSchema.parse(args);
+
+    // Reason: A subtransaction can itself be a transfer leg (e.g. a split where part of the
+    // amount is a purchase and part is a transfer to savings). Resolve each subtransaction's
+    // transfer_account_id into the corresponding transfer payee before sending to the API.
+    for (const t of transactions) {
+      if (!t.subtransactions) continue;
+      for (const sub of t.subtransactions) {
+        if (sub.transfer_account_id) {
+          const subTransferPayeeId = await resolveTransferPayee(sub.transfer_account_id);
+          if (!subTransferPayeeId) {
+            return error(
+              `No transfer payee found for account ${sub.transfer_account_id}. Ensure the destination account exists.`
+            );
+          }
+          sub.payee = subTransferPayeeId;
+        }
+        delete sub.transfer_account_id;
+      }
+    }
 
     // Reason: decimal amounts (e.g. 3.24) from the tool input are converted to integers (e.g. 324)
     // here before being passed to the API, which expects integer cents.

--- a/src/tools/update-transaction/index.test.ts
+++ b/src/tools/update-transaction/index.test.ts
@@ -4,9 +4,10 @@ import { handler, schema } from './index.js';
 // CRITICAL: Mock before imports
 vi.mock('../../actual-api.js', () => ({
   updateTransaction: vi.fn(),
+  getPayees: vi.fn(),
 }));
 
-import { updateTransaction } from '../../actual-api.js';
+import { updateTransaction, getPayees } from '../../actual-api.js';
 
 describe('update-transaction tool', () => {
   beforeEach(() => {
@@ -169,6 +170,47 @@ describe('update-transaction tool', () => {
         ],
       });
       expect(result.isError).toBeUndefined();
+    });
+
+    it('should resolve transfer payee for a subtransaction of a split', async () => {
+      vi.mocked(updateTransaction).mockResolvedValue(undefined);
+      vi.mocked(getPayees).mockResolvedValue([
+        { id: 'payee-savings', name: 'Transfer: Savings', transfer_acct: 'savings-account-id' },
+      ]);
+
+      const args = {
+        id: 'txn-123',
+        subtransactions: [
+          { id: 'sub-1', amount: -3000, category: 'cat-groceries' },
+          { id: 'sub-2', amount: -2000, transfer_account_id: 'savings-account-id' },
+        ],
+      };
+
+      const result = await handler(args);
+
+      expect(getPayees).toHaveBeenCalled();
+      expect(updateTransaction).toHaveBeenCalledWith('txn-123', {
+        subtransactions: [
+          { id: 'sub-1', amount: -3000, category: 'cat-groceries' },
+          { id: 'sub-2', amount: -2000, payee: 'payee-savings' },
+        ],
+      });
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should return error when a subtransaction transfer payee is not found', async () => {
+      vi.mocked(getPayees).mockResolvedValue([]);
+
+      const args = {
+        id: 'txn-123',
+        subtransactions: [{ id: 'sub-1', amount: -2000, transfer_account_id: 'nonexistent-account-id' }],
+      };
+
+      const result = await handler(args);
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('No transfer payee found');
+      expect(updateTransaction).not.toHaveBeenCalled();
     });
 
     it('should update multiple fields at once', async () => {

--- a/src/tools/update-transaction/index.ts
+++ b/src/tools/update-transaction/index.ts
@@ -2,12 +2,14 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { toJSONSchema } from 'zod';
 import { error, success, errorFromCatch } from '../../utils/response.js';
 import { updateTransaction } from '../../actual-api.js';
+import { resolveTransferPayee } from '../../core/data/resolve-transfer-payee.js';
 import { UpdateTransactionArgsSchema, type UpdateTransactionArgs, ToolInput } from '../../types.js';
 
 export const schema = {
   name: 'update-transaction',
   description:
-    'Update an existing transaction. Can modify date, amount, payee, category, notes, cleared status, and subtransactions.',
+    'Update an existing transaction. Can modify date, amount, payee, category, notes, cleared status, and ' +
+    'subtransactions, including turning a subtransaction into a transfer via transfer_account_id.',
   inputSchema: toJSONSchema(UpdateTransactionArgsSchema) as ToolInput,
 };
 
@@ -27,6 +29,24 @@ export async function handler(args: UpdateTransactionArgs): Promise<CallToolResu
 
     const validatedArgs = UpdateTransactionArgsSchema.parse(args);
     const { id: transactionId, ...updateData } = validatedArgs;
+
+    // Reason: A subtransaction can itself be a transfer leg (e.g. turning one line of an
+    // existing split into a transfer to savings). Resolve each subtransaction's
+    // transfer_account_id into the corresponding transfer payee before sending to the API.
+    if (updateData.subtransactions) {
+      for (const sub of updateData.subtransactions) {
+        if (sub.transfer_account_id) {
+          const subTransferPayeeId = await resolveTransferPayee(sub.transfer_account_id);
+          if (!subTransferPayeeId) {
+            return error(
+              `No transfer payee found for account ${sub.transfer_account_id}. Ensure the destination account exists.`
+            );
+          }
+          sub.payee = subTransferPayeeId;
+        }
+        delete sub.transfer_account_id;
+      }
+    }
 
     // Filter out undefined values to only send fields that were explicitly provided
     const filteredUpdateData = Object.fromEntries(

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,18 @@ export const UpdateSubtransactionSchema = z.object({
   amount: z.number().describe('Required for subtransactions. A currency amount as an integer'),
   category: z.string().optional().describe('The ID of the category for this subtransaction'),
   notes: z.string().optional().describe('Any additional notes for this subtransaction'),
+  payee: z
+    .string()
+    .optional()
+    .describe('An existing payee ID for this subtransaction. Overridden by transfer_account_id if both are given.'),
+  transfer_account_id: z
+    .string()
+    .optional()
+    .describe(
+      'The ID of the destination account for a transfer originating from this subtransaction (split leg). ' +
+        'When provided, the transfer payee is automatically resolved and the counterpart transaction is created ' +
+        'in the destination account. The amount should be negative (money leaving the source account).'
+    ),
 });
 
 export type UpdateSubtransaction = z.infer<typeof UpdateSubtransactionSchema>;
@@ -120,6 +132,18 @@ export const SubtransactionSchema = z.object({
   amount: z.number().describe('Required for subtransactions. A currency amount as an integer'),
   category: z.string().optional().describe('The ID of the category for this subtransaction'),
   notes: z.string().optional().describe('Any additional notes for this subtransaction'),
+  payee: z
+    .string()
+    .optional()
+    .describe('An existing payee ID for this subtransaction. Overridden by transfer_account_id if both are given.'),
+  transfer_account_id: z
+    .string()
+    .optional()
+    .describe(
+      'The ID of the destination account for a transfer originating from this subtransaction (split leg). ' +
+        'When provided, the transfer payee is automatically resolved and the counterpart transaction is created ' +
+        'in the destination account. The amount should be negative (money leaving the source account).'
+    ),
 });
 
 export type Subtransaction = z.infer<typeof SubtransactionSchema>;
@@ -190,6 +214,18 @@ export const ImportSubtransactionSchema = z.object({
     ),
   category: z.string().optional().describe('The ID of the category for this subtransaction'),
   notes: z.string().optional().describe('Any additional notes for this subtransaction'),
+  payee: z
+    .string()
+    .optional()
+    .describe('An existing payee ID for this subtransaction. Overridden by transfer_account_id if both are given.'),
+  transfer_account_id: z
+    .string()
+    .optional()
+    .describe(
+      'The ID of the destination account for a transfer originating from this subtransaction (split leg). ' +
+        'When provided, the transfer payee is automatically resolved and the counterpart transaction is created ' +
+        'in the destination account. The amount should be negative (money leaving the source account).'
+    ),
 });
 
 // Schema for a single transaction item in a bulk import.


### PR DESCRIPTION
## Problem

It's not possible to create a transfer from a subtransaction (split leg) — the call succeeds but no transfer/counterpart transaction is created, and no error is surfaced.

Root cause: `SubtransactionSchema`, `UpdateSubtransactionSchema`, and `ImportSubtransactionSchema` (`src/types.ts`) had no payee/transfer field. Zod strips unrecognized keys, so any transfer intent set on a split leg was silently dropped before reaching the API.

I verified against `@actual-app/core` 26.9.0 that the underlying API *does* support this at the data layer:
- `transfer.ts`'s `addTransfer()` only excludes `is_parent` rows, not children (`is_child`).
- `makeChild()` passes through a `payee` field on the child row when one is given.

So this was purely a schema/handler gap in this server, not an upstream Actual limitation.

## Fix

- Added `payee` + `transfer_account_id` to `SubtransactionSchema`, `UpdateSubtransactionSchema`, and `ImportSubtransactionSchema`, mirroring the existing top-level `transfer_account_id` convenience field.
- Extracted `resolveTransferPayee()` into `src/core/data/resolve-transfer-payee.ts` so `create-transaction`, `update-transaction`, and `import-transactions` can share it.
- Each handler now resolves a subtransaction's `transfer_account_id` into the corresponding transfer payee before calling the API (same pattern already used for the top-level transaction), and returns a clear error if the destination account has no transfer payee.

## Testing

- Added unit tests for the new resolver and for the transfer-on-subtransaction path in all three handlers (happy path + "payee not found" error case).
- `npm run type-check`, `npm run test` (212/212 passing), `npm run lint`, `npm run format:check`, `npm run build` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)