### PR TITLE
feat: expose split subtransaction ids via get-transactions

### DIFF
--- a/src/core/data/fetch-transactions.test.ts
+++ b/src/core/data/fetch-transactions.test.ts
@@ -117,6 +117,54 @@ describe('fetchTransactionsForAccount', () => {
     expect(fetchAllPayees).not.toHaveBeenCalled();
     expect(fetchAllCategories).not.toHaveBeenCalled();
   });
+
+  it('should enrich subtransactions of a split with their own payee and category names', async () => {
+    const mockTransactions = [
+      {
+        id: 'parent-1',
+        account: 'acc1',
+        date: '2023-01-01',
+        amount: -10000,
+        is_parent: true,
+        subtransactions: [
+          { id: 'child-1', account: 'acc1', date: '2023-01-01', amount: -6000, category: 'c1' },
+          { id: 'child-2', account: 'acc1', date: '2023-01-01', amount: -4000, payee: 'p1' },
+        ],
+      },
+    ];
+    vi.mocked(getTransactions).mockResolvedValue(mockTransactions);
+    vi.mocked(fetchAllPayees).mockResolvedValue([{ id: 'p1', name: 'Transfer: Savings' }]);
+    vi.mocked(fetchAllCategories).mockResolvedValue([{ id: 'c1', name: 'Groceries', group_id: 'g1' }]);
+
+    const result = await fetchTransactionsForAccount('acc1', '2023-01-01', '2023-01-31');
+
+    expect(result[0].subtransactions).toEqual([
+      { ...mockTransactions[0].subtransactions[0], category_name: 'Groceries' },
+      { ...mockTransactions[0].subtransactions[1], payee_name: 'Transfer: Savings' },
+    ]);
+    expect(fetchAllPayees).toHaveBeenCalledTimes(1);
+    expect(fetchAllCategories).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not request lookups when only subtransactions lack payee/category (edge case: none set anywhere)', async () => {
+    const mockTransactions = [
+      {
+        id: 'parent-1',
+        account: 'acc1',
+        date: '2023-01-01',
+        amount: -10000,
+        is_parent: true,
+        subtransactions: [{ id: 'child-1', account: 'acc1', date: '2023-01-01', amount: -10000 }],
+      },
+    ];
+    vi.mocked(getTransactions).mockResolvedValue(mockTransactions);
+
+    const result = await fetchTransactionsForAccount('acc1', '2023-01-01', '2023-01-31');
+
+    expect(result).toEqual(mockTransactions);
+    expect(fetchAllPayees).not.toHaveBeenCalled();
+    expect(fetchAllCategories).not.toHaveBeenCalled();
+  });
 });
 
 describe('fetchAllOnBudgetTransactions', () => {

--- a/src/core/data/fetch-transactions.ts
+++ b/src/core/data/fetch-transactions.ts
@@ -29,14 +29,50 @@ async function _buildTransactionLookups(options: TransactionLookupOptions): Prom
   return { payeesById, categoriesById };
 }
 
+// Reason: A split's subtransactions can each have their own payee/category (e.g. one leg is a
+// transfer, another is categorized spending), so lookup-need detection and name enrichment must
+// look one level into `subtransactions` as well as at the top-level transaction.
+function _hasField(transactions: TransactionEntity[], field: 'payee' | 'category'): boolean {
+  return transactions.some((t) => Boolean(t[field]) || (t.subtransactions ?? []).some((sub) => Boolean(sub[field])));
+}
+
+function _enrichSingleTransaction(
+  transaction: TransactionEntity,
+  payeesById: Record<string, Payee>,
+  categoriesById: Record<string, Category>,
+  needsPayees: boolean,
+  needsCategories: boolean
+): Transaction {
+  const payeeName = needsPayees && transaction.payee ? payeesById[transaction.payee]?.name : undefined;
+  const categoryName = needsCategories && transaction.category ? categoriesById[transaction.category]?.name : undefined;
+
+  const enriched: Transaction = { ...transaction };
+
+  if (payeeName !== undefined) {
+    enriched.payee_name = payeeName;
+  }
+
+  if (categoryName !== undefined) {
+    enriched.category_name = categoryName;
+  }
+
+  if (transaction.subtransactions) {
+    enriched.subtransactions = transaction.subtransactions.map((sub) =>
+      _enrichSingleTransaction(sub, payeesById, categoriesById, needsPayees, needsCategories)
+    );
+  }
+
+  return enriched;
+}
+
 async function _enrichTransactions(transactions: TransactionEntity[]): Promise<Transaction[]> {
   if (transactions.length === 0) {
     return transactions;
   }
 
   // # Reason: Only fetch lookup tables when transactions are missing names to avoid redundant API calls.
-  const needsPayees = transactions.some((transaction) => Boolean(transaction.payee));
-  const needsCategories = transactions.some((transaction) => Boolean(transaction.category));
+  const needsPayees = _hasField(transactions, 'payee');
+  const needsCategories = _hasField(transactions, 'category');
 
   if (!needsPayees && !needsCategories) {
     return transactions;
@@ -47,23 +83,9 @@ async function _enrichTransactions(transactions: TransactionEntity[]): Promise<T
     includeCategories: needsCategories,
   });
 
-  return transactions.map((transaction: TransactionEntity) => {
-    const payeeName = needsPayees && transaction.payee ? payeesById[transaction.payee]?.name : undefined;
-    const categoryName =
-      needsCategories && transaction.category ? categoriesById[transaction.category]?.name : undefined;
-
-    const enriched: Transaction = { ...transaction };
-
-    if (payeeName !== undefined) {
-      enriched.payee_name = payeeName;
-    }
-
-    if (categoryName !== undefined) {
-      enriched.category_name = categoryName;
-    }
-
-    return enriched;
-  });
+  return transactions.map((transaction) =>
+    _enrichSingleTransaction(transaction, payeesById, categoriesById, needsPayees, needsCategories)
+  );
 }
 
 export async function fetchTransactionsForAccount(

--- a/src/core/types/domain.ts
+++ b/src/core/types/domain.ts
@@ -21,6 +21,14 @@ export interface Transaction {
   notes?: string;
   transfer_id?: string;
   cleared?: boolean;
+  // Reason: Actual returns split transactions as a parent with a nested `subtransactions`
+  // array (one level deep) when queried with `splits: 'grouped'`, which is what the
+  // underlying getTransactions call uses. is_parent/is_child/parent_id mirror Actual's own
+  // TransactionEntity so callers can tell a split leg apart from a regular transaction.
+  is_parent?: boolean;
+  is_child?: boolean;
+  parent_id?: string;
+  subtransactions?: Transaction[];
 }
 
 export interface Category {

--- a/src/tools/get-transactions/report-generator.test.ts
+++ b/src/tools/get-transactions/report-generator.test.ts
@@ -57,4 +57,54 @@ describe('GetTransactionsReportGenerator', () => {
     expect(headers.slice(0, 7)).toEqual(['ID', 'Date', 'Payee', 'Category', 'Amount', 'Cleared', 'Notes']);
     expect(headers[7]).toBe('Transfer');
   });
+
+  it('renders a split subtransaction as its own row, nested under the parent, with its id visible', () => {
+    const splitRow = {
+      ...regularRow,
+      id: 'tx-parent',
+      subtransactions: [
+        {
+          id: 'tx-child-1',
+          date: '2024-05-02',
+          payee: '(No payee)',
+          category: 'Groceries',
+          amount: '-$8.00',
+          notes: '',
+          cleared: false,
+          transferId: '',
+        },
+        {
+          id: 'tx-child-2',
+          date: '2024-05-02',
+          payee: 'Transfer: Savings',
+          category: '(Uncategorized)',
+          amount: '-$4.34',
+          notes: '',
+          cleared: false,
+          transferId: 'tx-transfer-counterpart',
+        },
+      ],
+    };
+
+    const md = generator.generate([splitRow], '', 1, 1);
+    const lines = md.split('\n');
+    const parentIndex = lines.findIndex((line) => line.startsWith('| tx-parent |'));
+
+    expect(parentIndex).toBeGreaterThan(-1);
+    // The child rows immediately follow the parent row, keeping the id visible so it can be
+    // targeted with update-transaction (e.g. to turn a leg into a transfer).
+    expect(lines[parentIndex + 1]).toContain('| ↳ tx-child-1 |');
+    expect(lines[parentIndex + 1]).toContain('Groceries');
+    expect(lines[parentIndex + 2]).toContain('| ↳ tx-child-2 |');
+    expect(lines[parentIndex + 2]).toContain('tx-transfer-counterpart');
+  });
+
+  it('does not add any rows for a transaction without subtransactions', () => {
+    const md = generator.generate([regularRow], '', 1, 1);
+    const rowLines = md
+      .split('\n')
+      .filter((line) => line.startsWith('|') && !line.startsWith('| ID') && !line.startsWith('| ----'));
+
+    expect(rowLines).toHaveLength(1);
+  });
 });

--- a/src/tools/get-transactions/report-generator.ts
+++ b/src/tools/get-transactions/report-generator.ts
@@ -1,29 +1,29 @@
 // Generates the response/report for get-transactions tool
+import type { MappedTransaction } from './transaction-mapper.js';
 
 export class GetTransactionsReportGenerator {
   generate(
-    mappedTransactions: Array<{
-      id: string;
-      date: string;
-      payee: string;
-      category: string;
-      amount: string;
-      notes: string;
-      cleared: boolean;
-      transferId: string;
-    }>,
+    mappedTransactions: MappedTransaction[],
     filterDescription: string,
     filteredCount: number,
     totalCount: number
   ): string {
     const header =
       '| ID | Date | Payee | Category | Amount | Cleared | Notes | Transfer |\n| ---- | ----- | -------- | ------ | ----- | ------- | ----- | -------- |\n';
-    const rows = mappedTransactions
-      .map(
-        (t) =>
-          `| ${t.id} | ${t.date} | ${t.payee} | ${t.category} | ${t.amount} | ${t.cleared} | ${t.notes} | ${t.transferId} |`
-      )
-      .join('\n');
+    const rows = mappedTransactions.flatMap((t) => this._rowsFor(t)).join('\n');
     return `# Filtered Transactions\n\n${filterDescription}\nMatching Transactions: ${filteredCount}/${totalCount}\n\n${header}${rows}`;
+  }
+
+  // Reason: A split's subtransactions are rendered as extra rows right under their parent
+  // (id prefixed with "↳") so a subtransaction's id — needed to target it with
+  // update-transaction, e.g. to turn one leg into a transfer — is visible without adding a
+  // second table or changing the column count consumers already parse.
+  private _rowsFor(t: MappedTransaction): string[] {
+    const parentRow = `| ${t.id} | ${t.date} | ${t.payee} | ${t.category} | ${t.amount} | ${t.cleared} | ${t.notes} | ${t.transferId} |`;
+    const subRows = (t.subtransactions ?? []).map(
+      (sub) =>
+        `| ↳ ${sub.id} | ${sub.date} | ${sub.payee} | ${sub.category} | ${sub.amount} | ${sub.cleared} | ${sub.notes} | ${sub.transferId} |`
+    );
+    return [parentRow, ...subRows];
   }
 }

--- a/src/tools/get-transactions/transaction-mapper.test.ts
+++ b/src/tools/get-transactions/transaction-mapper.test.ts
@@ -53,4 +53,58 @@ describe('GetTransactionsMapper', () => {
     expect(mapped.cleared).toBe(false);
     expect(mapped.transferId).toBe('');
   });
+
+  it('omits subtransactions when the transaction is not a split', () => {
+    const tx: Transaction = {
+      id: 'tx-5',
+      account: 'acc-1',
+      date: '2024-05-04',
+      amount: -1000,
+    };
+
+    const [mapped] = mapper.map([tx]);
+
+    expect(mapped.subtransactions).toBeUndefined();
+  });
+
+  it('maps each subtransaction of a split, exposing its own id, payee, and transfer', () => {
+    const tx: Transaction = {
+      id: 'tx-parent',
+      account: 'acc-1',
+      date: '2024-05-05',
+      amount: -10000,
+      is_parent: true,
+      subtransactions: [
+        {
+          id: 'tx-child-1',
+          account: 'acc-1',
+          date: '2024-05-05',
+          amount: -6000,
+          category_name: 'Groceries',
+          is_child: true,
+          parent_id: 'tx-parent',
+        },
+        {
+          id: 'tx-child-2',
+          account: 'acc-1',
+          date: '2024-05-05',
+          amount: -4000,
+          payee_name: 'Transfer: Savings',
+          transfer_id: 'tx-transfer-counterpart',
+          is_child: true,
+          parent_id: 'tx-parent',
+        },
+      ],
+    };
+
+    const [mapped] = mapper.map([tx]);
+
+    expect(mapped.subtransactions).toHaveLength(2);
+    expect(mapped.subtransactions?.[0]).toMatchObject({ id: 'tx-child-1', category: 'Groceries' });
+    expect(mapped.subtransactions?.[1]).toMatchObject({
+      id: 'tx-child-2',
+      payee: 'Transfer: Savings',
+      transferId: 'tx-transfer-counterpart',
+    });
+  });
 });

--- a/src/tools/get-transactions/transaction-mapper.ts
+++ b/src/tools/get-transactions/transaction-mapper.ts
@@ -2,18 +2,27 @@
 import { formatAmount, formatDate } from '../../utils.js';
 import type { Transaction } from '../../types.js';
 
+export interface MappedTransaction {
+  id: string;
+  date: string;
+  payee: string;
+  category: string;
+  amount: string;
+  notes: string;
+  cleared: boolean;
+  transferId: string;
+  // Reason: A split's subtransactions are one level deep in Actual's model, so this is not
+  // recursive — a subtransaction row never has its own subtransactions.
+  subtransactions?: Omit<MappedTransaction, 'subtransactions'>[];
+}
+
 export class GetTransactionsMapper {
-  map(transactions: Transaction[]): Array<{
-    id: string;
-    date: string;
-    payee: string;
-    category: string;
-    amount: string;
-    notes: string;
-    cleared: boolean;
-    transferId: string;
-  }> {
-    return transactions.map((t) => ({
+  map(transactions: Transaction[]): MappedTransaction[] {
+    return transactions.map((t) => this._mapOne(t));
+  }
+
+  private _mapOne(t: Transaction): MappedTransaction {
+    return {
       id: t.id,
       date: formatDate(t.date),
       payee: t.payee_name || t.payee || '(No payee)',
@@ -22,6 +31,7 @@ export class GetTransactionsMapper {
       notes: t.notes || '',
       cleared: t.cleared ?? false,
       transferId: t.transfer_id || '',
-    }));
+      ...(t.subtransactions ? { subtransactions: t.subtransactions.map((sub) => this._mapOne(sub)) } : {}),
+    };
   }
 }


### PR DESCRIPTION
## Problem

Follow-up to #219. That PR made it possible to *create* a transfer originating from a split's subtransaction, and to update one *by id* — but `get-transactions` discarded the `subtransactions` array entirely, so there was no way to discover an existing split leg's id from this server. Without it, `update-transaction` could only target a specific existing leg (e.g. to turn it into a transfer) if you already knew that id from somewhere else, such as Actual's own UI.

## Fix

- Added `is_parent` / `is_child` / `parent_id` / `subtransactions` to the `Transaction` domain type (`src/core/types/domain.ts`), mirroring Actual's own `TransactionEntity`.
- `fetch-transactions.ts` now enriches each subtransaction's `payee_name`/`category_name` too — a split leg can have its own payee/category distinct from the parent — and still only fetches the lookup tables when something (parent or a leg) actually needs one.
- `GetTransactionsMapper` now maps each subtransaction alongside its parent (same row shape; one level deep, since Actual doesn't support nested splits).
- `GetTransactionsReportGenerator` renders each split leg as its own row directly under its parent, with the id prefixed by "↳", without changing the existing 8-column table shape or altering how non-split rows render.

## Testing

- Added tests for subtransaction enrichment (`fetch-transactions.test.ts`), mapping (`transaction-mapper.test.ts`), and rendering (`report-generator.test.ts`).
- All pre-existing tests pass unchanged (no behavior change for non-split transactions).
- `npm run type-check`, `npm run test` (209/209 passing), `npm run lint`, `npm run format:check`, `npm run build` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)