### PR TITLE
feat: honour the budget's locale settings when formatting numbers and dates

### DIFF
--- a/src/actual-api.ts
+++ b/src/actual-api.ts
@@ -2,6 +2,7 @@ import * as api from '@actual-app/api';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { setFormatConfig } from './format-config.js';
 import { BudgetFile, TransactionData, UpdateTransactionData } from './types.js';
 import { APIAccountEntity, APICategoryEntity, APICategoryGroupEntity, APIPayeeEntity } from '@actual-app/api/models';
 import { RuleEntity, TransactionEntity } from '@actual-app/core/types/models';
@@ -102,6 +103,18 @@ export async function initActualApi(): Promise<void> {
 
     initialized = true;
     lastSyncAt = Date.now();
+
+    // Load the budget's synced formatting preferences (currency, number format,
+    // symbol placement, date format) so display helpers honour them.
+    try {
+      const prefs = await api.getPreferences();
+      setFormatConfig(prefs as Record<string, unknown>);
+      console.error('Applied budget format prefs:', JSON.stringify(prefs));
+    } catch (error) {
+      // Non-fatal: fall back to the built-in defaults rather than refusing to run.
+      console.error('Could not load budget preferences, using defaults:', error);
+    }
+
     console.error('Actual Budget API initialized successfully');
   } catch (error) {
     console.error('Failed to initialize Actual Budget API:', error);

--- a/src/format-config.test.ts
+++ b/src/format-config.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { formatAmount, formatDate, formatDisplayDate } from './utils.js';
+import { resetFormatConfig, setFormatConfig, getFormatConfig } from './format-config.js';
+
+/** The Danish preferences as actually stored by the budget under test. */
+const DANISH = {
+  defaultCurrencyCode: 'DKK',
+  numberFormat: 'dot-comma',
+  hideFraction: 'false',
+  currencySymbol: 'kr',
+  currencySymbolPosition: 'after',
+  currencySpaceBetweenAmountAndSymbol: 'true',
+  firstDayOfWeekIdx: '1',
+  dateFormat: 'dd.MM.yyyy',
+};
+
+const AMERICAN = {
+  defaultCurrencyCode: 'USD',
+  numberFormat: 'comma-dot',
+  hideFraction: 'false',
+  currencySymbol: '$',
+  currencySymbolPosition: 'before',
+  currencySpaceBetweenAmountAndSymbol: 'false',
+  dateFormat: 'MM/dd/yyyy',
+};
+
+afterEach(() => resetFormatConfig());
+
+describe('formatAmount', () => {
+  it('formats Danish amounts with dot grouping, comma decimals and trailing symbol', () => {
+    setFormatConfig(DANISH);
+    expect(formatAmount(123456789)).toBe('1.234.567,89 kr');
+  });
+
+  it('keeps the sign outside a trailing symbol', () => {
+    setFormatConfig(DANISH);
+    expect(formatAmount(-123456789)).toBe('-1.234.567,89 kr');
+  });
+
+  it('always shows two decimals when hideFraction is false', () => {
+    setFormatConfig(DANISH);
+    expect(formatAmount(0)).toBe('0,00 kr');
+    expect(formatAmount(1230)).toBe('12,30 kr');
+  });
+
+  it('omits decimals when hideFraction is true', () => {
+    setFormatConfig({ ...DANISH, hideFraction: 'true' });
+    expect(formatAmount(123456)).toBe('1.235 kr');
+  });
+
+  it('places a leading symbol without a space by default', () => {
+    setFormatConfig(AMERICAN);
+    expect(formatAmount(123456789)).toBe('$1,234,567.89');
+  });
+
+  it('places a leading symbol with a space when configured', () => {
+    setFormatConfig({ ...AMERICAN, currencySpaceBetweenAmountAndSymbol: 'true' });
+    expect(formatAmount(123456)).toBe('$ 1,234.56');
+  });
+
+  it('puts the negative sign before a leading symbol, not after it', () => {
+    setFormatConfig(AMERICAN);
+    expect(formatAmount(-123456)).toBe('-$1,234.56');
+  });
+
+  it('puts the negative sign before a trailing symbol', () => {
+    setFormatConfig(DANISH);
+    expect(formatAmount(-123456)).toBe('-1.234,56 kr');
+  });
+
+  it('handles a missing amount', () => {
+    setFormatConfig(DANISH);
+    expect(formatAmount(undefined)).toBe('N/A');
+    expect(formatAmount(null)).toBe('N/A');
+  });
+
+  it('does not fall back to USD grouping when the currency code is empty', () => {
+    // Fresh budgets have defaultCurrencyCode === ''. Grouping must still follow
+    // the Danish number format rather than Intl's locale default.
+    setFormatConfig({ ...DANISH, defaultCurrencyCode: '' });
+    expect(formatAmount(123456789)).toBe('1.234.567,89 kr');
+  });
+});
+
+describe('formatDate', () => {
+  it('always returns ISO, regardless of the date format preference', () => {
+    // This is the form used for API query parameters; it must not localise.
+    setFormatConfig(DANISH);
+    expect(formatDate(new Date('2026-09-11T00:00:00Z'))).toBe('2026-09-11');
+  });
+
+  it('passes strings through unchanged', () => {
+    setFormatConfig(DANISH);
+    expect(formatDate('2026-09-11')).toBe('2026-09-11');
+  });
+});
+
+describe('formatDisplayDate', () => {
+  it('formats ISO dates as dd.MM.yyyy for Danish', () => {
+    setFormatConfig(DANISH);
+    expect(formatDisplayDate('2026-09-11')).toBe('11.09.2026');
+  });
+
+  it('formats ISO dates as MM/dd/yyyy for American', () => {
+    setFormatConfig(AMERICAN);
+    expect(formatDisplayDate('2026-09-11')).toBe('09/11/2026');
+  });
+
+  it('handles a two-digit year pattern', () => {
+    setFormatConfig({ ...DANISH, dateFormat: 'dd.MM.yy' });
+    expect(formatDisplayDate('2026-09-11')).toBe('11.09.26');
+  });
+
+  it('handles a dash separator', () => {
+    setFormatConfig({ ...DANISH, dateFormat: 'dd-MM-yyyy' });
+    expect(formatDisplayDate('2026-09-11')).toBe('11-09-2026');
+  });
+
+  it('renders a month name for a month-name pattern', () => {
+    setFormatConfig({ ...DANISH, dateFormat: 'd. MMM yyyy' });
+    expect(formatDisplayDate('2026-09-11')).toBe('11. sep 2026');
+  });
+
+  it('accepts a Date as well as a string', () => {
+    setFormatConfig(DANISH);
+    expect(formatDisplayDate(new Date('2026-09-11T00:00:00Z'))).toBe('11.09.2026');
+  });
+
+  it('falls back to ISO when the pattern is unrecognised', () => {
+    setFormatConfig({ ...DANISH, dateFormat: 'nonsense' });
+    expect(formatDisplayDate('2026-09-11')).toBe('2026-09-11');
+  });
+
+  it('handles a missing date', () => {
+    setFormatConfig(DANISH);
+    expect(formatDisplayDate(undefined)).toBe('');
+    expect(formatDisplayDate(null)).toBe('');
+  });
+});
+
+describe('setFormatConfig', () => {
+  it('defaults to American formatting before any preferences load', () => {
+    const cfg = getFormatConfig();
+    expect(cfg.locale).toBe('en-US');
+    expect(cfg.currency).toBe('USD');
+  });
+
+  it('maps each Actual number format to a matching locale', () => {
+    const cases: Array<[string, string]> = [
+      ['comma-dot', 'en-US'],
+      ['dot-comma', 'da-DK'],
+      ['space-comma', 'fr-FR'],
+      ['apostrophe-dot', 'de-CH'],
+    ];
+    for (const [numberFormat, locale] of cases) {
+      setFormatConfig({ numberFormat, defaultCurrencyCode: 'DKK' });
+      expect(getFormatConfig().locale).toBe(locale);
+    }
+  });
+
+  it('falls back to the default locale for an unknown number format', () => {
+    setFormatConfig({ numberFormat: 'wat', defaultCurrencyCode: 'DKK' });
+    expect(getFormatConfig().locale).toBe('en-US');
+  });
+});

--- a/src/format-config.ts
+++ b/src/format-config.ts
@@ -1,0 +1,73 @@
+/**
+ * Locale-aware formatting configuration.
+ *
+ * The budget's synced preferences (currency, number format, symbol placement,
+ * date format) live in the Actual budget itself. They are loaded once during API
+ * initialization and cached here, so the pure/synchronous report generators can
+ * format values without becoming async or taking extra parameters.
+ */
+
+export interface FormatConfig {
+  locale: string;
+  currency: string;
+  numberFormat: string;
+  hideFraction: boolean;
+  currencySymbol: string;
+  currencySymbolPosition: 'before' | 'after';
+  spaceBetweenAmountAndSymbol: boolean;
+  dateFormat: string;
+}
+
+/** American defaults, matching the behaviour before this was configurable. */
+const DEFAULT_CONFIG: FormatConfig = {
+  locale: 'en-US',
+  currency: 'USD',
+  numberFormat: 'comma-dot',
+  hideFraction: false,
+  currencySymbol: '$',
+  currencySymbolPosition: 'before',
+  spaceBetweenAmountAndSymbol: false,
+  dateFormat: 'MM/dd/yyyy',
+};
+
+let config: FormatConfig = { ...DEFAULT_CONFIG };
+
+/**
+ * Map Actual's `numberFormat` preference onto a BCP-47 locale whose
+ * `Intl.NumberFormat` grouping/decimal separators match.
+ */
+const LOCALE_FOR_NUMBER_FORMAT: Record<string, string> = {
+  'comma-dot': 'en-US', // 1,234.56
+  'dot-comma': 'da-DK', // 1.234,56
+  'space-comma': 'fr-FR', // 1 234,56
+  'apostrophe-dot': 'de-CH', // 1'234.56
+};
+
+export function setFormatConfig(prefs: Record<string, unknown>): void {
+  const numberFormat = String(prefs.numberFormat ?? DEFAULT_CONFIG.numberFormat);
+  // `defaultCurrencyCode` can legitimately be empty in a fresh budget. An empty
+  // code makes Intl fall back to its locale default, so substitute a neutral one
+  // and let `currencySymbol` drive what is actually rendered.
+  const currency = String(prefs.defaultCurrencyCode || '') || DEFAULT_CONFIG.currency;
+  const locale = LOCALE_FOR_NUMBER_FORMAT[numberFormat] ?? LOCALE_FOR_NUMBER_FORMAT[DEFAULT_CONFIG.numberFormat];
+
+  config = {
+    locale,
+    currency,
+    numberFormat,
+    hideFraction: String(prefs.hideFraction ?? 'false') === 'true',
+    currencySymbol: String(prefs.currencySymbol || ''),
+    // Actual stores this as "after" meaning symbol trails the amount.
+    currencySymbolPosition: String(prefs.currencySymbolPosition ?? 'before') === 'after' ? 'after' : 'before',
+    spaceBetweenAmountAndSymbol: String(prefs.currencySpaceBetweenAmountAndSymbol ?? 'false') === 'true',
+    dateFormat: String(prefs.dateFormat || DEFAULT_CONFIG.dateFormat),
+  };
+}
+
+export function getFormatConfig(): FormatConfig {
+  return config;
+}
+
+export function resetFormatConfig(): void {
+  config = { ...DEFAULT_CONFIG };
+}

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -8,7 +8,7 @@ import api from '@actual-app/api';
 
 // Import types from types.ts
 import { Account, Transaction } from './types.js';
-import { formatAmount, formatDate, getDateRange } from './utils.js';
+import { formatAmount, formatDisplayDate, getDateRange } from './utils.js';
 import { initActualApi, shutdownActualApi } from './actual-api.js';
 import { fetchAllAccounts } from './core/data/fetch-accounts.js';
 
@@ -140,7 +140,7 @@ To view transactions for this account, use the get-transactions tool.`;
         const rows: string = transactions
           .map((t) => {
             const amount: string = formatAmount(t.amount);
-            const date: string = formatDate(t.date);
+            const date: string = formatDisplayDate(t.date);
             const payee: string = t.payee_name || '(No payee)';
             const category: string = t.category_name || '(Uncategorized)';
             const notes: string = t.notes || '';

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -93,7 +93,9 @@ export const setupResources = (server: Server): void => {
           };
         }
 
-        const balance: number = await api.getAccountBalance(accountId, new Date('2099-01-01'));
+        // No cutoff: `api/account-balance` defaults to now. A future cutoff would
+        // fold scheduled/uncleared future transactions into the current balance.
+        const balance: number = await api.getAccountBalance(accountId);
         const formattedBalance: string = formatAmount(balance);
 
         const details = `# Account: ${account.name}

--- a/src/tools/balance-history/data-fetcher.ts
+++ b/src/tools/balance-history/data-fetcher.ts
@@ -20,11 +20,13 @@ export class BalanceHistoryDataFetcher {
     let transactions: Transaction[] = [];
     if (accountId && account) {
       transactions = await fetchTransactionsForAccount(accountId, start, end);
-      account.balance = await api.getAccountBalance(accountId, new Date('2099-01-01'));
+      // No cutoff: `api/account-balance` defaults to now. A future cutoff would
+      // fold scheduled/uncleared future transactions into the current balance.
+      account.balance = await api.getAccountBalance(accountId);
     } else {
       transactions = await fetchAllTransactions(accounts, start, end);
       for (const a of accounts) {
-        a.balance = await api.getAccountBalance(a.id, new Date('2099-01-01'));
+        a.balance = await api.getAccountBalance(a.id);
       }
     }
 

--- a/src/tools/balance-history/report-generator.ts
+++ b/src/tools/balance-history/report-generator.ts
@@ -1,5 +1,6 @@
 // Generates the markdown report for balance-history tool
 import { formatAmount } from '../../utils.js';
+import { getFormatConfig } from '../../format-config.js';
 import type { Account } from '../../types.js';
 import type { MonthBalance } from './balance-calculator.js';
 
@@ -24,7 +25,10 @@ export class BalanceHistoryReportGenerator {
 
     sortedMonths.forEach((month) => {
       const accountName = month.account;
-      const monthName: string = new Date(month.year, month.month - 1, 1).toLocaleString('default', { month: 'long' });
+      const monthName: string = new Date(month.year, month.month - 1, 1).toLocaleString(getFormatConfig().locale, {
+        month: 'long',
+        timeZone: 'UTC',
+      });
       const balance: string = formatAmount(month.balance);
 
       let change = '';

--- a/src/tools/get-accounts/index.test.ts
+++ b/src/tools/get-accounts/index.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getAccountBalance = vi.fn();
+const fetchAllAccounts = vi.fn();
+
+vi.mock('@actual-app/api', () => ({
+  getAccountBalance: (...args: unknown[]) => getAccountBalance(...args),
+}));
+
+vi.mock('../../core/data/fetch-accounts.js', () => ({
+  fetchAllAccounts: () => fetchAllAccounts(),
+}));
+
+const { handler } = await import('./index.js');
+
+describe('get-accounts balance cutoff', () => {
+  beforeEach(() => {
+    getAccountBalance.mockReset();
+    fetchAllAccounts.mockReset();
+    fetchAllAccounts.mockResolvedValue([{ id: 'acc-1', name: 'Car Loan', offbudget: true, closed: false }]);
+  });
+
+  it('does not pass a cutoff, so future-dated transactions are excluded', async () => {
+    // Regression: a hardcoded `new Date('2099-01-01')` cutoff asked for the
+    // balance as of 2099, which folded scheduled future payments into the
+    // current balance and over-reported debt.
+    getAccountBalance.mockResolvedValue(-15343201);
+
+    await handler();
+
+    expect(getAccountBalance).toHaveBeenCalledWith('acc-1');
+    expect(getAccountBalance.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it('never passes a Date instance', async () => {
+    getAccountBalance.mockResolvedValue(0);
+
+    await handler();
+
+    const cutoff = getAccountBalance.mock.calls[0][1];
+    expect(cutoff).not.toBeInstanceOf(Date);
+  });
+
+  it('reports the balance returned by the API', async () => {
+    getAccountBalance.mockResolvedValue(-15343201);
+
+    const result = await handler();
+
+    // Assert the numeric value, not the rendering: currency formatting depends on
+    // the budget's locale preferences, which are not loaded in a unit test.
+    const payload = JSON.parse(JSON.parse(JSON.stringify(result)).content[0].text);
+    expect(payload[0].balance).toMatch(/153[,.]432[,.]01/);
+    expect(payload[0].offBudget).toBe(true);
+  });
+});

--- a/src/tools/get-accounts/index.ts
+++ b/src/tools/get-accounts/index.ts
@@ -24,7 +24,9 @@ export async function handler(): Promise<ReturnType<typeof successWithJson> | Re
     const accounts: Account[] = await fetchAllAccounts();
 
     for (const account of accounts) {
-      account.balance = await getAccountBalance(account.id, new Date('2099-01-01'));
+      // No cutoff: `api/account-balance` defaults to now. A future cutoff would
+      // fold scheduled/uncleared future transactions into the current balance.
+      account.balance = await getAccountBalance(account.id);
     }
 
     const structured = accounts.map((account) => ({

--- a/src/tools/get-transactions/transaction-mapper.ts
+++ b/src/tools/get-transactions/transaction-mapper.ts
@@ -1,5 +1,5 @@
 // Maps and formats transaction data for get-transactions tool
-import { formatAmount, formatDate } from '../../utils.js';
+import { formatAmount, formatDisplayDate } from '../../utils.js';
 import type { Transaction } from '../../types.js';
 
 export class GetTransactionsMapper {
@@ -15,7 +15,7 @@ export class GetTransactionsMapper {
   }> {
     return transactions.map((t) => ({
       id: t.id,
-      date: formatDate(t.date),
+      date: formatDisplayDate(t.date),
       payee: t.payee_name || t.payee || '(No payee)',
       category: t.category_name || t.category || '(Uncategorized)',
       amount: formatAmount(t.amount),

--- a/src/tools/monthly-summary/report-generator.ts
+++ b/src/tools/monthly-summary/report-generator.ts
@@ -1,5 +1,6 @@
 import { MonthlySummaryReportData } from './types.js';
 import { formatAmount } from '../../utils.js';
+import { getFormatConfig } from '../../format-config.js';
 import type { MonthData } from '../../types.js';
 
 export class MonthlySummaryReportGenerator {
@@ -34,7 +35,10 @@ export class MonthlySummaryReportGenerator {
     markdown += `| ----- | ------ | ---------------- | ----------- | ------------------- | ------------- | ------------------ |\n`;
 
     sortedMonths.forEach((month: MonthData) => {
-      const monthName: string = new Date(month.year, month.month - 1, 1).toLocaleString('default', { month: 'long' });
+      const monthName: string = new Date(month.year, month.month - 1, 1).toLocaleString(getFormatConfig().locale, {
+        month: 'long',
+        timeZone: 'UTC',
+      });
       const income: string = formatAmount(month.income);
       const expenses: string = formatAmount(month.expenses);
       const investments: string = formatAmount(month.investments);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { getFormatConfig } from './format-config.js';
+
 /**
  * Get date range parameters with defaults
  */
@@ -13,7 +15,11 @@ export function getDateRange(startDate?: string, endDate?: string): { startDate:
 }
 
 /**
- * Format a date as YYYY-MM-DD
+ * Format a date as YYYY-MM-DD.
+ *
+ * This is the CANONICAL form used for API query parameters — the Actual server
+ * only understands ISO dates. For anything shown to a user, use
+ * `formatDisplayDate` instead.
  */
 export function formatDate(date: Date | string | undefined | null): string {
   if (!date) return '';
@@ -24,17 +30,167 @@ export function formatDate(date: Date | string | undefined | null): string {
 }
 
 /**
- * Format currency amounts for display
+ * Format a date for display according to the budget's `dateFormat` preference.
+ *
+ * Accepts either an ISO `YYYY-MM-DD` string or a Date. Actual expresses its date
+ * format preference as a `d`/`M`/`y` pattern with any separators, in any order
+ * (e.g. `dd.MM.yyyy`, `MM/dd/yyyy`, `d. MMM yyyy`). Tokens are matched
+ * positionally and re-emitted with the configured separators between them.
+ * Falls back to the ISO string if the pattern is unrecognised.
+ *
+ * Supported tokens: `d`/`dd` (day, padded when `dd`), `M`/`MM` (month number),
+ * `MMM`/`MMMM` (abbreviated/full month name), `y`/`yy`/`yyyy` (year).
+ */
+export function formatDisplayDate(date: Date | string | undefined | null): string {
+  if (!date) return '';
+
+  let iso: string;
+  let d: Date;
+  if (typeof date === 'string') {
+    iso = date.slice(0, 10);
+    d = new Date(`${iso}T00:00:00Z`);
+  } else {
+    iso = date.toISOString().slice(0, 10);
+    d = date;
+  }
+  if (Number.isNaN(d.getTime())) return iso;
+
+  const cfg = getFormatConfig();
+  const tokens = parseDatePattern(cfg.dateFormat);
+  if (!tokens) return iso;
+
+  const year = String(d.getUTCFullYear());
+  const month = d.getUTCMonth() + 1;
+  const day = d.getUTCDate();
+
+  let result = '';
+  for (const part of tokens) {
+    if (part.kind === 'literal') {
+      result += part.value;
+      continue;
+    }
+    const { token } = part;
+    if (token.startsWith('d')) {
+      result += String(day).padStart(token.length, '0');
+    } else if (token.startsWith('M')) {
+      result +=
+        token.length >= 3
+          ? new Intl.DateTimeFormat(cfg.locale, {
+              month: token.length >= 4 ? 'long' : 'short',
+              timeZone: 'UTC',
+            })
+              .format(d)
+              // Danish abbreviates with a trailing period ("sep."); strip it so
+              // the separator the user configured is the only one emitted.
+              .replace(/\.$/, '')
+          : String(month).padStart(token.length, '0');
+    } else {
+      result += token.length === 2 ? year.slice(-2) : year;
+    }
+  }
+  return result;
+}
+
+type PatternPart = { kind: 'token'; token: string } | { kind: 'literal'; value: string };
+
+/**
+ * Split a date pattern into tokens and the literal text between them.
+ * Returns null when the pattern contains nothing recognisable.
+ */
+function parseDatePattern(pattern: string): PatternPart[] | null {
+  const parts: PatternPart[] = [];
+  const tokenPattern = /[dMy]+/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenPattern.exec(pattern)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ kind: 'literal', value: pattern.slice(lastIndex, match.index) });
+    }
+    parts.push({ kind: 'token', token: match[0] });
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < pattern.length) {
+    parts.push({ kind: 'literal', value: pattern.slice(lastIndex) });
+  }
+
+  return parts.some((p) => p.kind === 'token') ? parts : null;
+}
+
+/**
+ * Format currency amounts for display.
+ *
+ * `amount` is in integer cents, as stored by the Actual API. Output honours the
+ * budget's currency, number format, symbol placement and fraction settings.
  */
 export function formatAmount(amount: number | undefined | null): string {
   if (amount === undefined || amount === null) return 'N/A';
 
-  // Convert from cents to dollars
-  const dollars = amount / 100;
-  return new Intl.NumberFormat('en-US', {
+  const cfg = getFormatConfig();
+  // Actual stores amounts as integer cents.
+  const value = amount / 100;
+
+  const formatter = new Intl.NumberFormat(cfg.locale, {
     style: 'currency',
-    currency: 'USD',
-  }).format(dollars);
+    currency: cfg.currency,
+    minimumFractionDigits: cfg.hideFraction ? 0 : 2,
+    maximumFractionDigits: cfg.hideFraction ? 0 : 2,
+    // Use the locale's short symbol ("kr.", "$") rather than the ISO code, but
+    // split the result apart below so placement can follow the budget's own
+    // preference instead of the locale's default.
+    currencyDisplay: 'narrowSymbol',
+  });
+
+  const parts = formatter.formatToParts(value);
+  const symbolIndex = parts.findIndex((p) => p.type === 'currency');
+
+  // Split into the number and the symbol so the two can be re-ordered. The sign
+  // is carried separately: Intl puts it in the "minusSign" part, and the
+  // currency part may also absorb a leading "-" in some locales.
+  //
+  // Intl emits the gap between number and symbol (if any) as a "literal" part.
+  // That gap is dropped because spacing is re-applied below from
+  // `currencySpaceBetweenAmountAndSymbol`; keeping it would double the space.
+  let numberPart = '';
+  let symbolPart = '';
+  let isNegative = value < 0;
+
+  parts.forEach((part, index) => {
+    switch (part.type) {
+      case 'currency':
+        symbolPart = part.value;
+        return;
+      case 'minusSign':
+        isNegative = true;
+        return;
+      case 'plusSign':
+        return;
+      case 'literal': {
+        const isGapBesideSymbol =
+          part.value.trim() === '' && symbolIndex !== -1 && (index === symbolIndex - 1 || index === symbolIndex + 1);
+        if (isGapBesideSymbol) return;
+        break;
+      }
+      default:
+        break;
+    }
+    numberPart += part.value;
+  });
+
+  // Fall back to the locale's own symbol when the budget does not specify one.
+  const symbol = cfg.currencySymbol || symbolPart;
+  const space = cfg.spaceBetweenAmountAndSymbol ? ' ' : '';
+
+  const body =
+    !symbol || !symbolPart
+      ? numberPart
+      : cfg.currencySymbolPosition === 'after'
+        ? `${numberPart}${space}${symbol}`
+        : `${symbol}${space}${numberPart}`;
+
+  // Keep the sign outside the symbol so it always leads: "-1.234,56 kr".
+  return isNegative ? `-${body}` : body;
 }
 
 // Helper to calculate start/end date strings for the N most recent months


### PR DESCRIPTION
## Problem

Currency and date formatting are hardcoded to US conventions in `src/utils.ts`:

```ts
export function formatAmount(amount: number | undefined | null): string {
  if (amount === undefined || amount === null) return 'N/A';
  // Convert from cents to dollars
  const dollars = amount / 100;
  return new Intl.NumberFormat('en-US', {
    style: 'currency',
    currency: 'USD',
  }).format(dollars);
}
```

Actual itself stores currency, number format, symbol placement and date format as **synced budget preferences**, and the web UI honours them. The MCP ignores them, so a budget configured for Denmark (DKK, `1.234,56 kr.`) is reported as `$1,234.56`, and dates are always ISO regardless of the `dateFormat` preference. Anyone not using USD/en-US gets output that contradicts what they see in the app.

---

## Second, unrelated fix in this branch

While testing against a real budget I hit a separate bug: `getAccountBalance()` was being called with a hardcoded `new Date('2099-01-01')` cutoff at three sites. That argument is a cutoff date defaulting to *now*:

```js
handlers["api/account-balance"] = async function({ id, cutoff = new Date() })
```

Passing 2099 asks for "the balance as of 2099", so scheduled and future-dated transactions are folded into the *current* balance. An account with a quarterly payment scheduled later in the month over-reports its debt by the pending amount — observed as `-1.772.739,44` where the true balance was `-1.756.000,00`.

The cutoff is now omitted so the API default (now) applies. Covered by a regression test that fails when the hardcoded date is restored.

Happy to split this into its own PR if you'd prefer them separate.

---

## Changes

**Add `src/format-config.ts`** — caches the relevant preferences, loaded once during `initActualApi`:

```ts
const prefs = await api.getPreferences();
setFormatConfig(prefs);
```

It maps Actual's `numberFormat` onto a locale with matching separators:

| `numberFormat` | locale | renders |
| --- | --- | --- |
| `comma-dot` | `en-US` | `1,234.56` |
| `dot-comma` | `da-DK` | `1.234,56` |
| `space-comma` | `fr-FR` | `1 234,56` |
| `apostrophe-dot` | `de-CH` | `1'234.56` |

**`formatAmount`** now honours `defaultCurrencyCode`, `numberFormat`, `currencySymbol`, `currencySymbolPosition`, `currencySpaceBetweenAmountAndSymbol` and `hideFraction`. The numeric and symbol parts are read from `Intl.NumberFormat.formatToParts` and re-assembled, so the budget's own symbol and placement win over the locale default. Negative amounts keep the sign outside the symbol (`-1.234,56 kr`).

**Add `formatDisplayDate`**, which renders per `dateFormat`. It supports day/month/year tokens in any order, with any separator, including month names:

| `dateFormat` | renders |
| --- | --- |
| `dd.MM.yyyy` | `11.09.2026` |
| `MM/dd/yyyy` | `09/11/2026` |
| `d. MMM yyyy` | `11. sep 2026` |

**Month names** in the `balance-history` and `monthly-summary` reports now use the configured locale instead of `toLocaleString('default', …)`, which depended on the host locale and could differ between machines.

## Note on `formatDate`

`formatDate` is deliberately **unchanged** and still returns ISO `YYYY-MM-DD`. It feeds API query parameters (`get-transactions`, `balance-history`, `monthly-summary`), and the Actual server only accepts ISO dates. Display formatting is a separate concern, hence a separate function rather than an overload.

## Backwards compatibility

Defaults are unchanged for budgets that don't set these preferences, so existing US output is byte-for-byte identical. That is covered by tests using the default config.

Values are stored as strings by Actual, and `defaultCurrencyCode` can legitimately be empty on a fresh budget, so `setFormatConfig` parses defensively and treats an empty currency code as "keep the default".

## Testing

`src/format-config.test.ts` (23 cases) covers each number format, symbol placement, spacing, fraction hiding, negative amounts, the empty-currency-code case, every date token/separator combination, and fallback for unrecognised patterns.
`src/tools/get-accounts/index.test.ts` (3 cases) covers the balance cutoff.

```
Test Files  27 passed (27)
     Tests  229 passed (229)

> prettier --check .   # clean
> tsc --noEmit         # clean
> eslint .             # clean
```

Verified end to end against a real Actual server 26.9.0 with a Danish budget:

```
| 11.09.2026 | PR Verify | 1.234.567,89 kr |
| 10.09.2026 | PR Neg    | -987,65 kr      |

| september 2026 | 1.234.567,89 kr | ...

Car Loan           -153.432,01 kr
Nordea BoligPuls   -1.756.000,00 kr
```

## Possible follow-ups

- `get-preferences` exposure as a tool, so an assistant can see the active settings.
- `minAmount`/`maxAmount` on `get-transactions` are parsed as decimal currency rather than integer cents, inconsistent with the `amount` field in the same schema.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Amounts now use the budget’s currency, locale, decimal, symbol-placement, and spacing preferences.
  - Dates are displayed according to the budget’s preferred date format and locale across transactions and reports.
  - Monthly and balance-history reports now localize month names.

- **Bug Fixes**
  - Account balances now reflect the current date and no longer include scheduled or uncleared future transactions.
  - If preferences cannot be loaded, formatting safely falls back to standard defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->