### PR TITLE
fix: keep release-please tags as v<version>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.13.0](https://github.com/s-stefanov/actual-mcp/compare/actual-mcp-v1.12.1...actual-mcp-v1.13.0) (2026-09-12)
+## [1.13.0](https://github.com/s-stefanov/actual-mcp/compare/v1.12.1...v1.13.0) (2026-09-12)
 
 
 ### Features

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "extra-files": [


### PR DESCRIPTION
## Summary
- The manifest-mode config added in #229 (for server.json syncing) made release-please default to `<component>-v<version>` tags, derived from `package.json`'s `name` field (`actual-mcp`). This produced `actual-mcp-v1.13.0` for the #216 release instead of the expected `v1.13.0`.
- Sets `include-component-in-tag: false` so tags stay `v<version>` as before.

## Related cleanup (already done on GitHub, not part of this diff)
- Deleted the `actual-mcp-v1.13.0` tag/release and recreated it as `v1.13.0` pointing at the same commit, so release-please's tag search finds the expected `v1.13.0` on the next run.

## Test plan
- [ ] Merge and confirm the next release-please PR/release uses a `v<version>` tag, not `actual-mcp-v<version>`